### PR TITLE
Issue/#2 assert error value has message

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ hashbrown = "0.15"
 float-cmp = { version = "0.10", optional = true }
 
 [dev-dependencies]
+anyhow = "1"
 version-sync = "0.9"
 
 [lints.rust]

--- a/README.md
+++ b/README.md
@@ -162,14 +162,15 @@ for the `Option` type.
 
 for the `Result` type.
 
-| assertion | description                                                                 |
-|-----------|-----------------------------------------------------------------------------|
-| is_ok     | verify that a result has an ok value                                        |                                                 
-| is_err    | verify that a result has an err value                                       |
-| has_value | verify that a result has an ok value that is equal to the expected value    |
-| has_error | verify that a result has an err value that is equal to the expected error   |
-| ok        | verify that a result has an ok value and map the subject to this ok value   |
-| err       | verify that a result has an err value and map the subject to this err value |
+| assertion         | description                                                                                              |
+|-------------------|----------------------------------------------------------------------------------------------------------|
+| is_ok             | verify that a result has an ok value                                                                     |                                                 
+| is_err            | verify that a result has an err value                                                                    |
+| has_value         | verify that a result has an ok value that is equal to the expected value                                 |
+| has_error         | verify that a result has an err value that is equal to the expected error                                |
+| has_error_message | verify that a result has an err value with a string representation that is equal to the expected message |
+| ok                | verify that a result has an ok value and map the subject to this ok value                                |
+| err               | verify that a result has an err value and map the subject to this err value                              |
 
 ### Emptiness
 

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -488,6 +488,39 @@ pub trait AssertHasError<E> {
     fn has_error(self, expected: E) -> Self;
 }
 
+/// Assert that a subject of some container type holds an error value that has
+/// a message equal to the expected message.
+///
+/// This is useful for opaque error types, that do not implement
+/// `PartialEq`. Since the `std::error::Error` trait requires that error
+/// types implement `Display`, the string representation of the error value
+/// is compared to an expected message string.
+///
+/// This assertion is implemented for the `Result` type. It compares the string
+/// representation of the error value with the expected message.
+///
+/// To assert the ok value of a `Result` use [`AssertHasValue::has_value`].
+///
+/// # Examples
+///
+/// ```
+/// use anyhow::anyhow;
+/// use asserting::prelude::*;
+///
+/// let subject: Result<(), anyhow::Error> = Err(anyhow!("mollit in ullamcorper no".to_string()));
+/// assert_that!(subject).has_error_message("mollit in ullamcorper no");
+/// ```
+pub trait AssertHasErrorMessage<'a, E, R> {
+    /// Verifies that the subject is an error value with the expected message.
+    ///
+    /// This is useful for opaque error types, that do not implement
+    /// `PartialEq`. Since the `std::error::Error` trait requires that error
+    /// types implement `Display`, the string representation of the error value
+    /// is compared to an expected message string.
+    #[track_caller]
+    fn has_error_message(self, expected_message: E) -> Spec<'a, String, R>;
+}
+
 /// Assert that a string contains a substring or character.
 ///
 /// # Examples

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -517,6 +517,8 @@ pub trait AssertHasErrorMessage<'a, E, R> {
     /// `PartialEq`. Since the `std::error::Error` trait requires that error
     /// types implement `Display`, the string representation of the error value
     /// is compared to an expected message string.
+    ///
+    /// This method panics if the actual subject is not an error value.
     #[track_caller]
     fn has_error_message(self, expected_message: E) -> Spec<'a, String, R>;
 }

--- a/src/result/tests.rs
+++ b/src/result/tests.rs
@@ -1,10 +1,12 @@
 use crate::prelude::*;
+use crate::std::fmt::{self, Display};
 #[cfg(not(feature = "std"))]
 use alloc::{
     string::{String, ToString},
     vec,
     vec::Vec,
 };
+use anyhow::anyhow;
 
 #[test]
 fn result_of_i32_is_ok() {
@@ -192,4 +194,28 @@ fn map_result_with_ok_value_to_its_err_value() {
     .panics_with_message(
         "assertion failed: expected the subject to be `Err(_)`, but was `Ok([1, 2, 3])`",
     );
+}
+
+#[test]
+fn result_error_has_message_for_an_anyhow_error() {
+    let subject: Result<(), anyhow::Error> = Err(anyhow!("id hendrerit clita kasd"));
+
+    assert_that!(subject).has_error_message("id hendrerit clita kasd");
+}
+
+#[test]
+fn result_error_has_message_for_custom_error_type() {
+    #[derive(Debug)]
+    struct OpaqueError(String);
+
+    impl Display for OpaqueError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(&self.0)
+        }
+    }
+
+    let subject: Result<(), OpaqueError> =
+        Err(OpaqueError("soluta dolor vero takimata".to_string()));
+
+    assert_that!(subject).has_error_message("soluta dolor vero takimata");
 }

--- a/tests/version_numbers.rs
+++ b/tests/version_numbers.rs
@@ -4,6 +4,7 @@
 // workaround for false positive 'unused extern crate' warnings until
 // Rust issue [#95513](https://github.com/rust-lang/rust/issues/95513) is fixed
 mod dummy_extern_uses {
+    use anyhow as _;
     use asserting as _;
     #[cfg(feature = "float")]
     use float_cmp as _;


### PR DESCRIPTION
Definition and implementation of the `AssertHasErrorMessage` assertion for the `Result` type.

we decided to implement the assertion directly on the subject.

```
assert_that!(subject).has_error_message("something went wrong");
```
