### PR TITLE
make proper use of the crate's own `std` module pattern

### DIFF
--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -12,8 +12,7 @@
 
 use crate::spec::Spec;
 use crate::std::ops::RangeInclusive;
-#[cfg(not(feature = "std"))]
-use alloc::string::String;
+use crate::std::string::String;
 
 /// Assert whether two values are equal or not.
 ///

--- a/src/boolean/mod.rs
+++ b/src/boolean/mod.rs
@@ -3,8 +3,8 @@
 use crate::assertions::AssertBoolean;
 use crate::expectations::{IsFalse, IsTrue};
 use crate::spec::{Expectation, Expression, FailingStrategy, Spec};
-#[cfg(not(feature = "std"))]
-use alloc::{format, string::String};
+use crate::std::format;
+use crate::std::string::String;
 
 impl<R> AssertBoolean for Spec<'_, bool, R>
 where

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -1,49 +1,104 @@
 //! Implementation of assertions for collections and iterators.
 
-use crate::prelude::{DefinedOrderProperty, IsEmptyProperty, LengthProperty};
+use crate::properties::{DefinedOrderProperty, IsEmptyProperty, LengthProperty};
+use crate::std::collections::{
+    btree_map, btree_set, linked_list, vec_deque, BTreeMap, BTreeSet, BinaryHeap, LinkedList,
+    VecDeque,
+};
 use crate::std::{array, slice};
-use hashbrown::{HashMap, HashSet};
+use crate::std::{vec, vec::Vec};
 
 impl<T> DefinedOrderProperty for [T] {}
 impl<T, const N: usize> DefinedOrderProperty for [T; N] {}
 impl<T, const N: usize> DefinedOrderProperty for array::IntoIter<T, N> {}
 impl<T> DefinedOrderProperty for slice::Iter<'_, T> {}
 impl<T> DefinedOrderProperty for slice::IterMut<'_, T> {}
+impl<T> DefinedOrderProperty for Vec<T> {}
+impl<T> DefinedOrderProperty for vec::IntoIter<T> {}
+impl<T> DefinedOrderProperty for BTreeSet<T> {}
+impl<T> DefinedOrderProperty for btree_set::IntoIter<T> {}
+impl<T> DefinedOrderProperty for btree_set::Iter<'_, T> {}
+impl<K, V> DefinedOrderProperty for btree_map::IntoIter<K, V> {}
+impl<K, V> DefinedOrderProperty for btree_map::Iter<'_, K, V> {}
+impl<T> DefinedOrderProperty for LinkedList<T> {}
+impl<T> DefinedOrderProperty for linked_list::IntoIter<T> {}
+impl<T> DefinedOrderProperty for linked_list::Iter<'_, T> {}
+impl<T> DefinedOrderProperty for linked_list::IterMut<'_, T> {}
+impl<T> DefinedOrderProperty for VecDeque<T> {}
+impl<T> DefinedOrderProperty for vec_deque::IntoIter<T> {}
+impl<T> DefinedOrderProperty for vec_deque::Iter<'_, T> {}
+impl<T> DefinedOrderProperty for vec_deque::IterMut<'_, T> {}
+
+impl<T> IsEmptyProperty for BinaryHeap<T> {
+    fn is_empty_property(&self) -> bool {
+        self.is_empty()
+    }
+}
+
+impl<K, V> IsEmptyProperty for BTreeMap<K, V> {
+    fn is_empty_property(&self) -> bool {
+        self.is_empty()
+    }
+}
+
+impl<T> IsEmptyProperty for BTreeSet<T> {
+    fn is_empty_property(&self) -> bool {
+        self.is_empty()
+    }
+}
+
+impl<T> IsEmptyProperty for LinkedList<T> {
+    fn is_empty_property(&self) -> bool {
+        self.is_empty()
+    }
+}
+
+impl<T> IsEmptyProperty for VecDeque<T> {
+    fn is_empty_property(&self) -> bool {
+        self.is_empty()
+    }
+}
+
+impl<T> LengthProperty for BinaryHeap<T> {
+    fn length_property(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<K, V> LengthProperty for BTreeMap<K, V> {
+    fn length_property(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<T> LengthProperty for BTreeSet<T> {
+    fn length_property(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<T> LengthProperty for LinkedList<T> {
+    fn length_property(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<T> LengthProperty for VecDeque<T> {
+    fn length_property(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<T, const N: usize> IsEmptyProperty for [T; N] {
+    fn is_empty_property(&self) -> bool {
+        self.is_empty()
+    }
+}
 
 #[cfg(feature = "std")]
 mod std {
-    use crate::prelude::{IsEmptyProperty, LengthProperty};
-    use crate::properties::DefinedOrderProperty;
-    use std::{
-        collections::{
-            btree_map, btree_set, linked_list, vec_deque, BTreeMap, BTreeSet, BinaryHeap, HashMap,
-            HashSet, LinkedList, VecDeque,
-        },
-        vec,
-    };
-
-    impl<T> DefinedOrderProperty for Vec<T> {}
-    impl<T> DefinedOrderProperty for vec::IntoIter<T> {}
-    impl<T> DefinedOrderProperty for BTreeSet<T> {}
-    impl<T> DefinedOrderProperty for btree_set::IntoIter<T> {}
-    impl<T> DefinedOrderProperty for btree_set::Iter<'_, T> {}
-    impl<K, V> DefinedOrderProperty for BTreeMap<K, V> {}
-    impl<K, V> DefinedOrderProperty for btree_map::IntoIter<K, V> {}
-    impl<K, V> DefinedOrderProperty for btree_map::Iter<'_, K, V> {}
-    impl<T> DefinedOrderProperty for LinkedList<T> {}
-    impl<T> DefinedOrderProperty for linked_list::IntoIter<T> {}
-    impl<T> DefinedOrderProperty for linked_list::Iter<'_, T> {}
-    impl<T> DefinedOrderProperty for linked_list::IterMut<'_, T> {}
-    impl<T> DefinedOrderProperty for VecDeque<T> {}
-    impl<T> DefinedOrderProperty for vec_deque::IntoIter<T> {}
-    impl<T> DefinedOrderProperty for vec_deque::Iter<'_, T> {}
-    impl<T> DefinedOrderProperty for vec_deque::IterMut<'_, T> {}
-
-    impl<T> IsEmptyProperty for BinaryHeap<T> {
-        fn is_empty_property(&self) -> bool {
-            self.is_empty()
-        }
-    }
+    use crate::properties::{IsEmptyProperty, LengthProperty};
+    use std::collections::{HashMap, HashSet};
 
     impl<K, V, S> IsEmptyProperty for HashMap<K, V, S> {
         fn is_empty_property(&self) -> bool {
@@ -57,37 +112,36 @@ mod std {
         }
     }
 
-    impl<K, V> IsEmptyProperty for BTreeMap<K, V> {
-        fn is_empty_property(&self) -> bool {
-            self.is_empty()
-        }
-    }
-
-    impl<T> IsEmptyProperty for BTreeSet<T> {
-        fn is_empty_property(&self) -> bool {
-            self.is_empty()
-        }
-    }
-
-    impl<T> IsEmptyProperty for LinkedList<T> {
-        fn is_empty_property(&self) -> bool {
-            self.is_empty()
-        }
-    }
-
-    impl<T> IsEmptyProperty for VecDeque<T> {
-        fn is_empty_property(&self) -> bool {
-            self.is_empty()
-        }
-    }
-
-    impl<T> LengthProperty for BinaryHeap<T> {
+    impl<K, V, S> LengthProperty for HashMap<K, V, S> {
         fn length_property(&self) -> usize {
             self.len()
         }
     }
 
-    impl<K, V> LengthProperty for BTreeMap<K, V> {
+    impl<T, S> LengthProperty for HashSet<T, S> {
+        fn length_property(&self) -> usize {
+            self.len()
+        }
+    }
+}
+
+mod hashbrown {
+    use crate::properties::{IsEmptyProperty, LengthProperty};
+    use hashbrown::{HashMap, HashSet};
+
+    impl<K, V, S> IsEmptyProperty for HashMap<K, V, S> {
+        fn is_empty_property(&self) -> bool {
+            self.is_empty()
+        }
+    }
+
+    impl<T, S> IsEmptyProperty for HashSet<T, S> {
+        fn is_empty_property(&self) -> bool {
+            self.is_empty()
+        }
+    }
+
+    impl<T, const N: usize> LengthProperty for [T; N] {
         fn length_property(&self) -> usize {
             self.len()
         }
@@ -103,146 +157,5 @@ mod std {
         fn length_property(&self) -> usize {
             self.len()
         }
-    }
-
-    impl<T> LengthProperty for BTreeSet<T> {
-        fn length_property(&self) -> usize {
-            self.len()
-        }
-    }
-
-    impl<T> LengthProperty for LinkedList<T> {
-        fn length_property(&self) -> usize {
-            self.len()
-        }
-    }
-
-    impl<T> LengthProperty for VecDeque<T> {
-        fn length_property(&self) -> usize {
-            self.len()
-        }
-    }
-}
-
-#[cfg(not(feature = "std"))]
-mod no_std {
-    use crate::prelude::{IsEmptyProperty, LengthProperty};
-    use crate::properties::DefinedOrderProperty;
-    use alloc::{
-        collections::{
-            btree_set, linked_list, vec_deque, BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque,
-        },
-        vec,
-        vec::Vec,
-    };
-
-    impl<T> DefinedOrderProperty for Vec<T> {}
-    impl<T> DefinedOrderProperty for vec::IntoIter<T> {}
-    impl<T> DefinedOrderProperty for BTreeSet<T> {}
-    impl<T> DefinedOrderProperty for btree_set::IntoIter<T> {}
-    impl<T> DefinedOrderProperty for btree_set::Iter<'_, T> {}
-    impl<T> DefinedOrderProperty for LinkedList<T> {}
-    impl<T> DefinedOrderProperty for linked_list::IntoIter<T> {}
-    impl<T> DefinedOrderProperty for linked_list::Iter<'_, T> {}
-    impl<T> DefinedOrderProperty for linked_list::IterMut<'_, T> {}
-    impl<T> DefinedOrderProperty for VecDeque<T> {}
-    impl<T> DefinedOrderProperty for vec_deque::IntoIter<T> {}
-    impl<T> DefinedOrderProperty for vec_deque::Iter<'_, T> {}
-    impl<T> DefinedOrderProperty for vec_deque::IterMut<'_, T> {}
-
-    impl<T> IsEmptyProperty for BinaryHeap<T> {
-        fn is_empty_property(&self) -> bool {
-            self.is_empty()
-        }
-    }
-
-    impl<K, V> IsEmptyProperty for BTreeMap<K, V> {
-        fn is_empty_property(&self) -> bool {
-            self.is_empty()
-        }
-    }
-
-    impl<T> IsEmptyProperty for BTreeSet<T> {
-        fn is_empty_property(&self) -> bool {
-            self.is_empty()
-        }
-    }
-
-    impl<T> IsEmptyProperty for LinkedList<T> {
-        fn is_empty_property(&self) -> bool {
-            self.is_empty()
-        }
-    }
-
-    impl<T> IsEmptyProperty for VecDeque<T> {
-        fn is_empty_property(&self) -> bool {
-            self.is_empty()
-        }
-    }
-
-    impl<T> LengthProperty for BinaryHeap<T> {
-        fn length_property(&self) -> usize {
-            self.len()
-        }
-    }
-
-    impl<K, V> LengthProperty for BTreeMap<K, V> {
-        fn length_property(&self) -> usize {
-            self.len()
-        }
-    }
-
-    impl<T> LengthProperty for BTreeSet<T> {
-        fn length_property(&self) -> usize {
-            self.len()
-        }
-    }
-
-    impl<T> LengthProperty for LinkedList<T> {
-        fn length_property(&self) -> usize {
-            self.len()
-        }
-    }
-
-    impl<T> LengthProperty for VecDeque<T> {
-        fn length_property(&self) -> usize {
-            self.len()
-        }
-    }
-}
-
-impl<T, const N: usize> IsEmptyProperty for [T; N] {
-    fn is_empty_property(&self) -> bool {
-        self.is_empty()
-    }
-}
-
-impl<K, V, S> IsEmptyProperty for HashMap<K, V, S> {
-    fn is_empty_property(&self) -> bool {
-        self.is_empty()
-    }
-}
-
-impl<T, S> IsEmptyProperty for HashSet<T, S> {
-    fn is_empty_property(&self) -> bool {
-        self.is_empty()
-    }
-}
-
-impl<T, const N: usize> LengthProperty for [T; N] {
-    fn length_property(&self) -> usize {
-        self.len()
-    }
-}
-
-impl<K, V, S> LengthProperty for HashMap<K, V, S> {
-    fn length_property(&self) -> usize {
-        self.len()
-    }
-}
-
-impl<T, S> LengthProperty for HashSet<T, S> {
-    fn length_property(&self) -> usize {
-        self.len()
     }
 }

--- a/src/equality.rs
+++ b/src/equality.rs
@@ -4,8 +4,7 @@ use crate::assertions::AssertEquality;
 use crate::expectations::{IsEqualTo, IsNotEqualTo};
 use crate::spec::{Expectation, Expression, FailingStrategy, Spec};
 use crate::std::fmt::Debug;
-#[cfg(not(feature = "std"))]
-use alloc::{format, string::String};
+use crate::std::{format, string::String};
 
 impl<S, E, R> AssertEquality<E> for Spec<'_, S, R>
 where

--- a/src/expectations.rs
+++ b/src/expectations.rs
@@ -3,8 +3,7 @@
 #![allow(missing_docs)]
 
 use crate::std::ops::RangeInclusive;
-#[cfg(not(feature = "std"))]
-use alloc::{string::String, vec::Vec};
+use crate::std::{string::String, vec::Vec};
 use hashbrown::HashSet;
 
 pub struct IsTrue;

--- a/src/float/mod.rs
+++ b/src/float/mod.rs
@@ -1,8 +1,7 @@
 use crate::assertions::{AssertIsCloseToWithDefaultMargin, AssertIsCloseToWithinMargin};
 use crate::expectations::{IsCloseTo, IsNotCloseTo};
 use crate::spec::{Expectation, Expression, FailingStrategy, Spec};
-#[cfg(not(feature = "std"))]
-use alloc::{format, string::String};
+use crate::std::{format, string::String};
 use float_cmp::{ApproxEq, F32Margin, F64Margin};
 
 impl<R> AssertIsCloseToWithDefaultMargin<f32> for Spec<'_, f32, R>

--- a/src/iterator/mod.rs
+++ b/src/iterator/mod.rs
@@ -13,8 +13,7 @@ use crate::spec::{Expectation, Expression, FailingStrategy, Spec};
 use crate::std::cmp::Ordering;
 use crate::std::fmt::Debug;
 use crate::std::mem;
-#[cfg(not(feature = "std"))]
-use alloc::{format, string::String, vec, vec::Vec};
+use crate::std::{format, string::String, vec, vec::Vec};
 use hashbrown::HashSet;
 
 impl<'a, S, T, E, R> AssertIteratorContains<'a, Vec<T>, E, R> for Spec<'a, S, R>

--- a/src/iterator/tests.rs
+++ b/src/iterator/tests.rs
@@ -1,8 +1,5 @@
 use crate::prelude::*;
-#[cfg(feature = "std")]
-use crate::std::vec;
-#[cfg(not(feature = "std"))]
-use alloc::{vec, vec::Vec};
+use crate::std::{vec, vec::Vec};
 
 #[derive(Debug)]
 struct CustomCollection<T> {

--- a/src/length.rs
+++ b/src/length.rs
@@ -1,14 +1,12 @@
 //! Implementations of the emptiness and length assertions.
 
-use crate::assertions::AssertHasLength;
+use crate::assertions::{AssertEmptiness, AssertHasLength};
 use crate::expectations::{HasLength, HasLengthInRange, IsEmpty, IsNotEmpty};
-use crate::prelude::{AssertEmptiness, LengthProperty};
-use crate::properties::IsEmptyProperty;
+use crate::properties::{IsEmptyProperty, LengthProperty};
 use crate::spec::{Expectation, Expression, FailingStrategy, Spec};
 use crate::std::fmt::Debug;
 use crate::std::ops::RangeInclusive;
-#[cfg(not(feature = "std"))]
-use alloc::{format, string::String};
+use crate::std::{format, string::String};
 
 impl<S, R> AssertEmptiness for Spec<'_, S, R>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -558,11 +558,35 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(not(feature = "std"))]
-extern crate alloc;
-
-#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
 mod std {
+    extern crate alloc;
+    pub use alloc::*;
     pub use core::*;
+
+    pub mod borrow {
+        extern crate alloc;
+        pub use alloc::borrow::*;
+        pub use core::borrow::*;
+    }
+
+    pub mod fmt {
+        extern crate alloc;
+        pub use alloc::fmt::*;
+        pub use core::fmt::*;
+    }
+
+    pub mod slice {
+        extern crate alloc;
+        pub use alloc::slice::*;
+        pub use core::slice::*;
+    }
+
+    pub mod str {
+        extern crate alloc;
+        pub use alloc::str::*;
+        pub use core::str::*;
+    }
 }
 
 #[cfg(feature = "std")]

--- a/src/option/mod.rs
+++ b/src/option/mod.rs
@@ -4,8 +4,7 @@ use crate::assertions::{AssertHasValue, AssertOption, AssertOptionValue};
 use crate::expectations::{HasValue, IsNone, IsSome};
 use crate::spec::{Expectation, Expression, FailingStrategy, Spec, Unknown};
 use crate::std::fmt::Debug;
-#[cfg(not(feature = "std"))]
-use alloc::{format, string::String};
+use crate::std::{format, string::String};
 
 impl<S, R> AssertOption for Spec<'_, Option<S>, R>
 where

--- a/src/option/tests.rs
+++ b/src/option/tests.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
-#[cfg(not(feature = "std"))]
-use alloc::{
+use crate::std::{
     string::{String, ToString},
     vec,
 };

--- a/src/order/mod.rs
+++ b/src/order/mod.rs
@@ -4,8 +4,7 @@ use crate::assertions::AssertOrder;
 use crate::expectations::{IsAtLeast, IsAtMost, IsGreaterThan, IsLessThan};
 use crate::spec::{Expectation, Expression, FailingStrategy, Spec};
 use crate::std::fmt::Debug;
-#[cfg(not(feature = "std"))]
-use alloc::{format, string::String};
+use crate::std::{format, string::String};
 
 impl<S, E, R> AssertOrder<E> for Spec<'_, S, R>
 where

--- a/src/predicate/mod.rs
+++ b/src/predicate/mod.rs
@@ -2,8 +2,7 @@
 
 use crate::expectations::Predicate;
 use crate::spec::{Expectation, Expression};
-#[cfg(not(feature = "std"))]
-use alloc::{format, string::String};
+use crate::std::{format, string::String};
 
 impl<S, P> Expectation<S> for Predicate<P>
 where

--- a/src/range/mod.rs
+++ b/src/range/mod.rs
@@ -6,8 +6,7 @@ use crate::properties::IsEmptyProperty;
 use crate::spec::{Expectation, Expression, FailingStrategy, Spec};
 use crate::std::fmt::Debug;
 use crate::std::ops::{Range, RangeBounds, RangeInclusive};
-#[cfg(not(feature = "std"))]
-use alloc::{format, string::String};
+use crate::std::{format, string::String};
 
 impl<T> IsEmptyProperty for Range<T>
 where

--- a/src/result/mod.rs
+++ b/src/result/mod.rs
@@ -5,8 +5,7 @@ use crate::expectations::{HasError, HasValue, IsEqualTo, IsErr, IsOk};
 use crate::prelude::{AssertHasError, AssertHasValue};
 use crate::spec::{Expectation, Expression, FailingStrategy, Spec, Unknown};
 use crate::std::fmt::{Debug, Display};
-#[cfg(not(feature = "std"))]
-use alloc::{
+use crate::std::{
     format,
     string::{String, ToString},
 };

--- a/src/result/tests.rs
+++ b/src/result/tests.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 use crate::std::fmt::{self, Display};
-#[cfg(not(feature = "std"))]
-use alloc::{
+use crate::std::{
     string::{String, ToString},
     vec,
     vec::Vec,

--- a/src/slice/tests.rs
+++ b/src/slice/tests.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 use crate::std::slice;
-#[cfg(not(feature = "std"))]
-use alloc::{
+use crate::std::{
     string::{String, ToString},
     vec,
     vec::Vec,

--- a/src/spec/mod.rs
+++ b/src/spec/mod.rs
@@ -4,8 +4,7 @@ use crate::expectations::Predicate;
 use crate::std::error::Error as StdError;
 use crate::std::fmt::{self, Debug, Display};
 use crate::std::ops::Deref;
-#[cfg(not(feature = "std"))]
-use alloc::{
+use crate::std::{
     borrow::ToOwned,
     string::{String, ToString},
     vec,

--- a/src/spec/tests.rs
+++ b/src/spec/tests.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 use crate::spec::{AssertFailure, Expression, OwnedLocation};
-#[cfg(not(feature = "std"))]
-use alloc::{
+use crate::std::{
     format,
     string::{String, ToString},
 };

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -13,8 +13,7 @@ use crate::properties::{IsEmptyProperty, LengthProperty};
 use crate::spec::{Expectation, Expression, FailingStrategy, Spec};
 use crate::std::fmt::Debug;
 use crate::std::str::Chars;
-#[cfg(not(feature = "std"))]
-use alloc::{format, string::String};
+use crate::std::{format, string::String};
 
 impl IsEmptyProperty for &str {
     fn is_empty_property(&self) -> bool {

--- a/src/string/tests.rs
+++ b/src/string/tests.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
-#[cfg(not(feature = "std"))]
-use alloc::string::{String, ToString};
+use crate::std::string::{String, ToString};
 
 #[test]
 fn string_is_equal_to_string() {

--- a/src/vec/mod.rs
+++ b/src/vec/mod.rs
@@ -1,8 +1,7 @@
 //! Implementation of assertions for `Vec` values.
 
-use crate::prelude::{IsEmptyProperty, LengthProperty};
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+use crate::properties::{IsEmptyProperty, LengthProperty};
+use crate::std::vec::Vec;
 
 impl<T> IsEmptyProperty for Vec<T> {
     fn is_empty_property(&self) -> bool {

--- a/src/vec/tests.rs
+++ b/src/vec/tests.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
-#[cfg(not(feature = "std"))]
-use alloc::{
+use crate::std::{
     string::{String, ToString},
     vec,
     vec::Vec,


### PR DESCRIPTION
improved the re-exports in the `crate::std` module and removed all direct imports from the `alloc` crate.