### PR TITLE
refactor: move implementation of assertions for `CString`/`CStr` to own modules

### DIFF
--- a/src/c_string/mod.rs
+++ b/src/c_string/mod.rs
@@ -1,0 +1,19 @@
+//! Implementation of assertions for `CString` and `CStr` values.
+
+use crate::properties::IsEmptyProperty;
+use crate::std::ffi::{CStr, CString};
+
+impl IsEmptyProperty for CString {
+    fn is_empty_property(&self) -> bool {
+        self.is_empty()
+    }
+}
+
+impl IsEmptyProperty for &CStr {
+    fn is_empty_property(&self) -> bool {
+        self.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/c_string/tests.rs
+++ b/src/c_string/tests.rs
@@ -1,0 +1,34 @@
+use crate::prelude::*;
+use crate::std::ffi::{CStr, CString};
+
+#[test]
+fn c_str_is_empty() {
+    let subject: &CStr = CStr::from_bytes_until_nul(b"\0")
+        .unwrap_or_else(|err| panic!("could not create CStr: {err}"));
+
+    assert_that(subject).is_empty();
+}
+
+#[test]
+fn c_str_is_not_empty() {
+    let subject: &CStr = CStr::from_bytes_until_nul(b"facilisi dolores nostrud aliquyam\0")
+        .unwrap_or_else(|err| panic!("could not create CStr: {err}"));
+
+    assert_that(subject).is_not_empty();
+}
+
+#[test]
+fn c_string_is_empty() {
+    let subject: CString =
+        CString::new(b"").unwrap_or_else(|err| panic!("could not create a CString: {err}"));
+
+    assert_that(subject).is_empty();
+}
+
+#[test]
+fn c_string_is_not_empty() {
+    let subject: CString = CString::new(b"anim ea aute aliqua")
+        .unwrap_or_else(|err| panic!("could not create a CString: {err}"));
+
+    assert_that(subject).is_not_empty();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -596,6 +596,12 @@ mod std {
         pub use alloc::str::*;
         pub use core::str::*;
     }
+
+    pub mod ffi {
+        extern crate alloc;
+        pub use alloc::ffi::*;
+        pub use core::ffi::*;
+    }
 }
 
 #[cfg(feature = "std")]
@@ -611,6 +617,7 @@ pub mod properties;
 pub mod spec;
 
 mod boolean;
+mod c_string;
 mod collection;
 mod equality;
 mod integer;
@@ -618,6 +625,8 @@ mod iterator;
 mod length;
 mod option;
 mod order;
+#[cfg(feature = "std")]
+mod os_sting;
 mod predicate;
 mod range;
 mod result;

--- a/src/os_sting/mod.rs
+++ b/src/os_sting/mod.rs
@@ -1,0 +1,35 @@
+//! Implementation of assertions for `OsString` and `OsStr` values.
+//!
+//! `OsString` and `OsStr` are only available in std environments. Thus,
+//! assertions for those types are only available with crate feature `std`
+//! enabled.
+
+use crate::properties::{IsEmptyProperty, LengthProperty};
+use crate::std::ffi::{OsStr, OsString};
+
+impl IsEmptyProperty for OsString {
+    fn is_empty_property(&self) -> bool {
+        self.is_empty()
+    }
+}
+
+impl LengthProperty for OsString {
+    fn length_property(&self) -> usize {
+        self.len()
+    }
+}
+
+impl IsEmptyProperty for &OsStr {
+    fn is_empty_property(&self) -> bool {
+        self.is_empty()
+    }
+}
+
+impl LengthProperty for &OsStr {
+    fn length_property(&self) -> usize {
+        self.len()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/os_sting/tests.rs
+++ b/src/os_sting/tests.rs
@@ -1,0 +1,44 @@
+use crate::prelude::*;
+use crate::std::ffi::{OsStr, OsString};
+
+#[test]
+fn os_str_is_empty() {
+    let subject: &OsStr = OsStr::new("");
+
+    assert_that(subject).is_empty();
+}
+
+#[test]
+fn os_str_is_not_empty() {
+    let subject: &OsStr = OsStr::new("officia praesent minim feugait");
+
+    assert_that(subject).is_not_empty();
+}
+
+#[test]
+fn os_string_is_empty() {
+    let subject: OsString = OsString::new();
+
+    assert_that(subject).is_empty();
+}
+
+#[test]
+fn os_string_is_not_empty() {
+    let subject: OsString = OsString::from("anim ea aute aliqua");
+
+    assert_that(subject).is_not_empty();
+}
+
+#[test]
+fn os_str_has_length() {
+    let subject: &OsStr = OsStr::new("A");
+
+    assert_that(subject).has_length(1);
+}
+
+#[test]
+fn os_string_has_length() {
+    let subject: OsString = OsString::from("ABC");
+
+    assert_that(subject).has_length(3);
+}

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -1,10 +1,4 @@
-//! Implementation of assertions for string values.
-//!
-//! String assertions are implemented for all string types of Rust:
-//!
-//! * `String` and `str`
-//! * `OsString` and `OsStr`
-//! * `CString` and `CStr`
+//! Implementation of assertions for `String` and `str` values.
 
 use crate::assertions::{AssertStringContainsAnyOf, AssertStringPattern};
 use crate::colored::{
@@ -41,54 +35,6 @@ impl IsEmptyProperty for String {
 impl LengthProperty for String {
     fn length_property(&self) -> usize {
         self.len()
-    }
-}
-
-#[cfg(feature = "std")]
-mod os_string {
-    use crate::properties::{IsEmptyProperty, LengthProperty};
-    use crate::std::ffi::{OsStr, OsString};
-
-    impl IsEmptyProperty for OsString {
-        fn is_empty_property(&self) -> bool {
-            self.is_empty()
-        }
-    }
-
-    impl LengthProperty for OsString {
-        fn length_property(&self) -> usize {
-            self.len()
-        }
-    }
-
-    impl IsEmptyProperty for &OsStr {
-        fn is_empty_property(&self) -> bool {
-            self.is_empty()
-        }
-    }
-
-    impl LengthProperty for &OsStr {
-        fn length_property(&self) -> usize {
-            self.len()
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-mod c_string {
-    use crate::properties::IsEmptyProperty;
-    use crate::std::ffi::{CStr, CString};
-
-    impl IsEmptyProperty for CString {
-        fn is_empty_property(&self) -> bool {
-            self.is_empty()
-        }
-    }
-
-    impl IsEmptyProperty for &CStr {
-        fn is_empty_property(&self) -> bool {
-            self.is_empty()
-        }
     }
 }
 

--- a/src/string/tests.rs
+++ b/src/string/tests.rs
@@ -119,82 +119,6 @@ fn str_is_not_empty() {
     assert_that(subject).is_not_empty();
 }
 
-#[cfg(feature = "std")]
-#[test]
-fn os_str_is_empty() {
-    use crate::std::ffi::OsStr;
-    let subject: &OsStr = OsStr::new("");
-
-    assert_that(subject).is_empty();
-}
-
-#[cfg(feature = "std")]
-#[test]
-fn os_str_is_not_empty() {
-    use crate::std::ffi::OsStr;
-    let subject: &OsStr = OsStr::new("officia praesent minim feugait");
-
-    assert_that(subject).is_not_empty();
-}
-
-#[cfg(feature = "std")]
-#[test]
-fn os_string_is_empty() {
-    use crate::std::ffi::OsString;
-    let subject: OsString = OsString::new();
-
-    assert_that(subject).is_empty();
-}
-
-#[cfg(feature = "std")]
-#[test]
-fn os_string_is_not_empty() {
-    use crate::std::ffi::OsString;
-    let subject: OsString = OsString::from("anim ea aute aliqua");
-
-    assert_that(subject).is_not_empty();
-}
-
-#[cfg(feature = "std")]
-#[test]
-fn c_str_is_empty() {
-    use crate::std::ffi::CStr;
-    let subject: &CStr = CStr::from_bytes_until_nul(b"\0")
-        .unwrap_or_else(|err| panic!("could not create CStr: {err}"));
-
-    assert_that(subject).is_empty();
-}
-
-#[cfg(feature = "std")]
-#[test]
-fn c_str_is_not_empty() {
-    use crate::std::ffi::CStr;
-    let subject: &CStr = CStr::from_bytes_until_nul(b"facilisi dolores nostrud aliquyam\0")
-        .unwrap_or_else(|err| panic!("could not create CStr: {err}"));
-
-    assert_that(subject).is_not_empty();
-}
-
-#[cfg(feature = "std")]
-#[test]
-fn c_string_is_empty() {
-    use crate::std::ffi::CString;
-    let subject: CString =
-        CString::new(b"").unwrap_or_else(|err| panic!("could not create a CString: {err}"));
-
-    assert_that(subject).is_empty();
-}
-
-#[cfg(feature = "std")]
-#[test]
-fn c_string_is_not_empty() {
-    use crate::std::ffi::CString;
-    let subject: CString = CString::new(b"anim ea aute aliqua")
-        .unwrap_or_else(|err| panic!("could not create a CString: {err}"));
-
-    assert_that(subject).is_not_empty();
-}
-
 #[test]
 fn verify_str_is_empty_fails() {
     let subject: &str = "ABC";
@@ -243,24 +167,6 @@ fn str_has_length() {
     let subject: &str = "ad fugiat duo erat";
 
     assert_that(subject).has_length(18);
-}
-
-#[cfg(feature = "std")]
-#[test]
-fn os_str_has_length() {
-    use crate::std::ffi::OsStr;
-    let subject: &OsStr = OsStr::new("A");
-
-    assert_that(subject).has_length(1);
-}
-
-#[cfg(feature = "std")]
-#[test]
-fn os_string_has_length() {
-    use crate::std::ffi::OsString;
-    let subject: OsString = OsString::from("ABC");
-
-    assert_that(subject).has_length(3);
 }
 
 #[test]


### PR DESCRIPTION
The implementation of assertions for `CString`/`CStr` and `OsString`/`OsStr` are currently mixed with `String`/`&str` in one module.

For clearer code base and overview what is implemented for which type the implementations for `CString`/`CStr` and `OsString`/`OsStr` have been moved to their own separate modules.