### PR TITLE
feat: implement `LengthProperty` for `CString` and `CStr`

### DIFF
--- a/src/c_string/mod.rs
+++ b/src/c_string/mod.rs
@@ -1,6 +1,6 @@
 //! Implementation of assertions for `CString` and `CStr` values.
 
-use crate::properties::IsEmptyProperty;
+use crate::properties::{IsEmptyProperty, LengthProperty};
 use crate::std::ffi::{CStr, CString};
 
 impl IsEmptyProperty for CString {
@@ -12,6 +12,18 @@ impl IsEmptyProperty for CString {
 impl IsEmptyProperty for &CStr {
     fn is_empty_property(&self) -> bool {
         self.is_empty()
+    }
+}
+
+impl LengthProperty for CString {
+    fn length_property(&self) -> usize {
+        self.as_bytes().len()
+    }
+}
+
+impl LengthProperty for &CStr {
+    fn length_property(&self) -> usize {
+        self.to_bytes().len()
     }
 }
 

--- a/src/c_string/tests.rs
+++ b/src/c_string/tests.rs
@@ -32,3 +32,19 @@ fn c_string_is_not_empty() {
 
     assert_that(subject).is_not_empty();
 }
+
+#[test]
+fn c_str_has_length() {
+    let subject: &CStr = CStr::from_bytes_until_nul(b"exerci euismod enim stet\0")
+        .unwrap_or_else(|err| panic!("could not create CStr: {err}"));
+
+    assert_that(subject).has_length(24);
+}
+
+#[test]
+fn c_string_has_length() {
+    let subject: CString = CString::new(b"enim lobortis aliquyam sunt")
+        .unwrap_or_else(|err| panic!("could not create a CString: {err}"));
+
+    assert_that(subject).has_length(27);
+}


### PR DESCRIPTION
Until now the assertion `has_length` was not available for the types `CString` and `CStr`.

This has been fixed by implementing the `LengthProperty` trait for `CString` and `CStr`.