### PR TITLE
feat: assertions for number of chararcters in strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,18 +171,38 @@ for `bool`.
 
 ### String
 
-for all string types of Rust: `String`, `str`, `OsString`, `OsStr`, `CString` and `CStr`.
+for strings of type `String` and `str`:
 
-| assertion           | description                                                              |
-|---------------------|--------------------------------------------------------------------------|
-| is_empty            | verify that a string is empty                                            |                                                 
-| is_not_empty        | verify that a string is not empty                                        |
-| has_length          | verify that a string has exactly the expected length                     |                                                 
-| has_length_in_range | verify that a string has a length that is in the expected range          |
-| contains            | verify that a string contains the expected substring or character        |
-| starts_with         | verify that a string starts with the expected substring or character     |
-| ends_with           | verify that a string ends with the expected substring or character       |
-| contains_any_of     | verify that a string contains any character from a collection of `char`s |
+| assertion               | description                                                                |
+|-------------------------|----------------------------------------------------------------------------|
+| is_empty                | verify that a string is empty                                              |                                                 
+| is_not_empty            | verify that a string is not empty                                          |
+| has_length              | verify that a string has exactly the expected length                       |                                                 
+| has_length_in_range     | verify that a string has a length that is in the expected range            |
+| has_char_count          | verify that a string contains exactly the expected number of characters    |                                                 
+| has_char_count_in_range | verify that a string contains a number of characters in the expected range |
+| contains                | verify that a string contains the expected substring or character          |
+| starts_with             | verify that a string starts with the expected substring or character       |
+| ends_with               | verify that a string ends with the expected substring or character         |
+| contains_any_of         | verify that a string contains any character from a collection of `char`s   |
+
+for strings of type `CString` and `CStr`:
+
+| assertion           | description                                                     |
+|---------------------|-----------------------------------------------------------------|
+| is_empty            | verify that a string is empty                                   |                                                 
+| is_not_empty        | verify that a string is not empty                               |
+| has_length          | verify that a string has exactly the expected length            |                                                 
+| has_length_in_range | verify that a string has a length that is in the expected range |
+
+for strings of type `OsString` and `OsStr` (requires crate feature `std`):
+
+| assertion           | description                                                     |
+|---------------------|-----------------------------------------------------------------|
+| is_empty            | verify that a string is empty                                   |                                                 
+| is_not_empty        | verify that a string is not empty                               |
+| has_length          | verify that a string has exactly the expected length            |                                                 
+| has_length_in_range | verify that a string has a length that is in the expected range |
 
 ### Option
 

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -328,6 +328,39 @@ pub trait AssertHasLength<E> {
     fn has_length_in_range(self, range: RangeInclusive<E>) -> Self;
 }
 
+/// Assert the number of characters contained in a string or similar container.
+///
+/// These assertions are implemented for all types `T` that implement the trait
+/// [`CharCountProperty`](crate::properties::CharCountProperty). This property
+/// is implemented for `String` and `&str`.
+///
+/// # Examples
+///
+/// ```
+/// use asserting::prelude::*;
+///
+/// let subject = "imper \u{0180} diet al \u{02AA} \u{01AF} zzril";
+/// assert_that(subject).has_length(28);
+/// assert_that(subject).has_char_count(25);
+/// assert_that(subject).has_char_count_in_range(12..=36);
+///
+/// let subject = "imper diet al zzril";
+/// assert_that(subject).has_length(19);
+/// assert_that(subject).has_char_count(19);
+/// ```
+pub trait AssertHasCharCount<E> {
+    /// Verifies that the subject contains the expected number of characters.
+    #[track_caller]
+    fn has_char_count(self, expected: E) -> Self;
+
+    /// Verifies that the subject contains a number of characters that is in the
+    /// expected range.
+    ///
+    /// The expected range must be a closed range with both ends inclusive.
+    #[track_caller]
+    fn has_char_count_in_range(self, range: RangeInclusive<E>) -> Self;
+}
+
 /// Assert whether a subject of the `Option` type holds some value or has none.
 ///
 /// # Examples

--- a/src/char_count.rs
+++ b/src/char_count.rs
@@ -1,0 +1,65 @@
+//! Implementations of the character count assertions.
+
+use crate::assertions::AssertHasCharCount;
+use crate::colored::{mark_missing, mark_unexpected};
+use crate::expectations::{HasCharCount, HasCharCountInRange};
+use crate::properties::CharCountProperty;
+use crate::spec::{DiffFormat, Expectation, Expression, FailingStrategy, Spec};
+use crate::std::fmt::Debug;
+use crate::std::format;
+use crate::std::ops::RangeInclusive;
+use crate::std::string::String;
+
+impl<S, R> AssertHasCharCount<usize> for Spec<'_, S, R>
+where
+    S: CharCountProperty + Debug,
+    R: FailingStrategy,
+{
+    fn has_char_count(self, expected: usize) -> Self {
+        self.expecting(HasCharCount {
+            expected_char_count: expected,
+        })
+    }
+
+    fn has_char_count_in_range(self, range: RangeInclusive<usize>) -> Self {
+        self.expecting(HasCharCountInRange {
+            expected_range: range,
+        })
+    }
+}
+
+impl<S> Expectation<S> for HasCharCount<usize>
+where
+    S: CharCountProperty + Debug,
+{
+    fn test(&mut self, subject: &S) -> bool {
+        subject.char_count_property() == self.expected_char_count
+    }
+
+    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+        let marked_actual = mark_unexpected(&actual.char_count_property(), format);
+        let marked_expected = mark_missing(&self.expected_char_count, format);
+        format!(
+            "expected {expression} has a char count of {:?}\n   but was: {marked_actual}\n  expected: {marked_expected}",
+            self.expected_char_count
+        )
+    }
+}
+
+impl<S> Expectation<S> for HasCharCountInRange<usize>
+where
+    S: CharCountProperty + Debug,
+{
+    fn test(&mut self, subject: &S) -> bool {
+        self.expected_range.contains(&subject.char_count_property())
+    }
+
+    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+        let marked_actual = mark_unexpected(&actual.char_count_property(), format);
+        let marked_expected = mark_missing(&self.expected_range, format);
+        format!(
+            "expected {expression} has a char count of {:?}\n   but was: {marked_actual}\n  expected: {marked_expected}",
+            self.expected_range,
+        )
+    }
+}

--- a/src/expectations.rs
+++ b/src/expectations.rs
@@ -142,6 +142,16 @@ pub struct HasLengthInRange<E> {
 }
 
 #[must_use]
+pub struct HasCharCount<E> {
+    pub expected_char_count: E,
+}
+
+#[must_use]
+pub struct HasCharCountInRange<E> {
+    pub expected_range: RangeInclusive<E>,
+}
+
+#[must_use]
 pub struct StringContains<E> {
     pub expected: E,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -618,6 +618,7 @@ pub mod spec;
 
 mod boolean;
 mod c_string;
+mod char_count;
 mod collection;
 mod equality;
 mod integer;

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -80,3 +80,27 @@ pub trait DefinedOrderProperty {}
 
 impl<C> DefinedOrderProperty for &C where C: DefinedOrderProperty + ?Sized {}
 impl<C> DefinedOrderProperty for &mut C where C: DefinedOrderProperty + ?Sized {}
+
+/// Property for types that contain characters.
+pub trait CharCountProperty {
+    /// Returns the number of characters contained in this type.
+    fn char_count_property(&self) -> usize;
+}
+
+impl<T> CharCountProperty for &T
+where
+    T: CharCountProperty + ?Sized,
+{
+    fn char_count_property(&self) -> usize {
+        <T as CharCountProperty>::char_count_property(self)
+    }
+}
+
+impl<T> CharCountProperty for &mut T
+where
+    T: CharCountProperty + ?Sized,
+{
+    fn char_count_property(&self) -> usize {
+        <T as CharCountProperty>::char_count_property(self)
+    }
+}

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -5,7 +5,7 @@ use crate::colored::{
     mark_missing, mark_missing_char, mark_missing_substr, mark_unexpected, mark_unexpected_substr,
 };
 use crate::expectations::{StringContains, StringContainsAnyOf, StringEndsWith, StringStartWith};
-use crate::properties::{DefinedOrderProperty, IsEmptyProperty, LengthProperty};
+use crate::properties::{CharCountProperty, DefinedOrderProperty, IsEmptyProperty, LengthProperty};
 use crate::spec::{DiffFormat, Expectation, Expression, FailingStrategy, Spec};
 use crate::std::fmt::Debug;
 use crate::std::str::Chars;
@@ -20,21 +20,33 @@ impl IsEmptyProperty for &str {
     }
 }
 
-impl LengthProperty for &str {
-    fn length_property(&self) -> usize {
-        self.len()
-    }
-}
-
 impl IsEmptyProperty for String {
     fn is_empty_property(&self) -> bool {
         self.is_empty()
     }
 }
 
+impl LengthProperty for &str {
+    fn length_property(&self) -> usize {
+        self.len()
+    }
+}
+
 impl LengthProperty for String {
     fn length_property(&self) -> usize {
         self.len()
+    }
+}
+
+impl CharCountProperty for &str {
+    fn char_count_property(&self) -> usize {
+        self.chars().count()
+    }
+}
+
+impl CharCountProperty for String {
+    fn char_count_property(&self) -> usize {
+        self.chars().count()
     }
 }
 

--- a/src/string/tests.rs
+++ b/src/string/tests.rs
@@ -106,6 +106,20 @@ fn string_is_not_empty() {
 }
 
 #[test]
+fn borrowed_string_is_empty() {
+    let subject: &String = &String::new();
+
+    assert_that(subject).is_empty();
+}
+
+#[test]
+fn mutable_borrowed_string_is_empty() {
+    let subject: &mut String = &mut String::new();
+
+    assert_that(subject).is_empty();
+}
+
+#[test]
 fn str_is_empty() {
     let subject: &str = "";
 
@@ -163,6 +177,13 @@ fn string_has_length() {
 }
 
 #[test]
+fn mutable_borrowed_string_has_length() {
+    let subject: &mut String = &mut "aute lobortis voluptua pariatur".to_string();
+
+    assert_that(subject).has_length(31);
+}
+
+#[test]
 fn str_has_length() {
     let subject: &str = "ad fugiat duo erat";
 
@@ -209,6 +230,97 @@ fn verify_has_length_in_range_fails() {
             r"assertion failed: expected my_thing has length in range 1..=24
    but was: 25
   expected: 1..=24
+"
+        ]
+    );
+}
+
+#[test]
+fn string_has_char_count() {
+    let subject: String = "option\u{0074}\u{02B0} sadipscing accusam augue".to_string();
+
+    assert_that(&subject).has_length(34);
+    assert_that(subject).has_char_count(33);
+}
+
+#[test]
+fn borrowed_string_has_char_count() {
+    let subject: &String = &"option\u{0074}\u{02B0} sadipscing accusam augue".to_string();
+
+    assert_that(subject).has_length(34);
+    assert_that(subject).has_char_count(33);
+}
+
+#[test]
+fn mutable_borrowed_string_has_char_count() {
+    let subject: &mut String = &mut "option\u{0074}\u{02B0} sadipscing accusam augue".to_string();
+
+    assert_that(&subject).has_length(34);
+    assert_that(subject).has_char_count(33);
+}
+
+#[test]
+fn str_has_char_count() {
+    let subject: &str = "imper\u{0180}diet al\u{02AA}iquyam \u{01AF} zzril aliquip";
+
+    assert_that(subject).has_length(39);
+    assert_that(subject).has_char_count(36);
+}
+
+#[test]
+fn verify_str_has_char_count_fails() {
+    let subject: &str = "\u{0112} \u{0034} \u{0200}";
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .has_char_count(7)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[r"assertion failed: expected my_thing has a char count of 7
+   but was: 5
+  expected: 7
+"]
+    );
+}
+
+#[test]
+fn string_has_char_count_in_range() {
+    let subject: String = "\u{0112} \u{0034} \u{0200}".to_string();
+
+    assert_that(subject).has_char_count_in_range(5..=5);
+}
+
+#[test]
+fn borrowed_string_has_char_count_in_range() {
+    let subject: &String = &"\u{0112} \u{0034} \u{0200}".to_string();
+
+    assert_that(subject).has_char_count_in_range(5..=5);
+}
+
+#[test]
+fn str_has_char_count_in_range() {
+    let subject: &str = "\u{0112} \u{0034} \u{0200}";
+
+    assert_that(subject).has_char_count_in_range(5..=5);
+}
+
+#[test]
+fn verify_str_has_char_count_in_range_fails() {
+    let subject: &str = "\u{0112} \u{0034} \u{0200}";
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .has_char_count_in_range(6..=12)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing has a char count of 6..=12
+   but was: 5
+  expected: 6..=12
 "
         ]
     );


### PR DESCRIPTION
Provide assertions for the number of characters contained in a string of type `String` or `&str`. 

implemented assertions are `has_char_count` and `has_char_count_in_range`.