### PR TITLE
feat: implement more length assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,22 +173,26 @@ for `bool`.
 
 for strings of type `String` and `str`:
 
-| assertion               | description                                                                    |
-|-------------------------|--------------------------------------------------------------------------------|
-| is_empty                | verify that a string is empty                                                  |                                                 
-| is_not_empty            | verify that a string is not empty                                              |
-| has_length              | verify that a string has exactly the expected length                           |                                                 
-| has_length_in_range     | verify that a string has a length that is in the expected range                |
-| has_length_less_than    | verify that a string has a length less than the expected length                |
-| has_length_greater_than | verify that a string has a length greater than the expected length             |
-| has_at_most_length      | verify that a string has a length less than or equal to the expected length    |
-| has_at_least_length     | verify that a string has a length greater than or equal to the expected length |
-| has_char_count          | verify that a string contains exactly the expected number of characters        |                                                 
-| has_char_count_in_range | verify that a string contains a number of characters in the expected range     |
-| contains                | verify that a string contains the expected substring or character              |
-| starts_with             | verify that a string starts with the expected substring or character           |
-| ends_with               | verify that a string ends with the expected substring or character             |
-| contains_any_of         | verify that a string contains any character from a collection of `char`s       |
+| assertion                   | description                                                                    |
+|-----------------------------|--------------------------------------------------------------------------------|
+| is_empty                    | verify that a string is empty                                                  |                                                 
+| is_not_empty                | verify that a string is not empty                                              |
+| has_length                  | verify that a string has exactly the expected length                           |                                                 
+| has_length_in_range         | verify that a string has a length that is in the expected range                |
+| has_length_less_than        | verify that a string has a length less than the expected length                |
+| has_length_greater_than     | verify that a string has a length greater than the expected length             |
+| has_at_most_length          | verify that a string has a length less than or equal to the expected length    |
+| has_at_least_length         | verify that a string has a length greater than or equal to the expected length |
+| has_char_count              | verify that a string contains exactly the expected number of characters        |                                                 
+| has_char_count_in_range     | verify that a string contains a number of characters in the expected range     |
+| has_char_count_less_than    | verify that a string contains less than the expected number of characters      |
+| has_char_count_greater_than | verify that a string contains more than the expected number of characters      |
+| has_at_most_char_count      | verify that a string contains at most the expected number of characters        |
+| has_at_least_char_count     | verify that a string contains at least the expected number of characters       |
+| contains                    | verify that a string contains the expected substring or character              |
+| starts_with                 | verify that a string starts with the expected substring or character           |
+| ends_with                   | verify that a string ends with the expected substring or character             |
+| contains_any_of             | verify that a string contains any character from a collection of `char`s       |
 
 for strings of type `CString` and `CStr`:
 

--- a/README.md
+++ b/README.md
@@ -173,36 +173,48 @@ for `bool`.
 
 for strings of type `String` and `str`:
 
-| assertion               | description                                                                |
-|-------------------------|----------------------------------------------------------------------------|
-| is_empty                | verify that a string is empty                                              |                                                 
-| is_not_empty            | verify that a string is not empty                                          |
-| has_length              | verify that a string has exactly the expected length                       |                                                 
-| has_length_in_range     | verify that a string has a length that is in the expected range            |
-| has_char_count          | verify that a string contains exactly the expected number of characters    |                                                 
-| has_char_count_in_range | verify that a string contains a number of characters in the expected range |
-| contains                | verify that a string contains the expected substring or character          |
-| starts_with             | verify that a string starts with the expected substring or character       |
-| ends_with               | verify that a string ends with the expected substring or character         |
-| contains_any_of         | verify that a string contains any character from a collection of `char`s   |
+| assertion               | description                                                                    |
+|-------------------------|--------------------------------------------------------------------------------|
+| is_empty                | verify that a string is empty                                                  |                                                 
+| is_not_empty            | verify that a string is not empty                                              |
+| has_length              | verify that a string has exactly the expected length                           |                                                 
+| has_length_in_range     | verify that a string has a length that is in the expected range                |
+| has_length_less_than    | verify that a string has a length less than the expected length                |
+| has_length_greater_than | verify that a string has a length greater than the expected length             |
+| has_at_most_length      | verify that a string has a length less than or equal to the expected length    |
+| has_at_least_length     | verify that a string has a length greater than or equal to the expected length |
+| has_char_count          | verify that a string contains exactly the expected number of characters        |                                                 
+| has_char_count_in_range | verify that a string contains a number of characters in the expected range     |
+| contains                | verify that a string contains the expected substring or character              |
+| starts_with             | verify that a string starts with the expected substring or character           |
+| ends_with               | verify that a string ends with the expected substring or character             |
+| contains_any_of         | verify that a string contains any character from a collection of `char`s       |
 
 for strings of type `CString` and `CStr`:
 
-| assertion           | description                                                     |
-|---------------------|-----------------------------------------------------------------|
-| is_empty            | verify that a string is empty                                   |                                                 
-| is_not_empty        | verify that a string is not empty                               |
-| has_length          | verify that a string has exactly the expected length            |                                                 
-| has_length_in_range | verify that a string has a length that is in the expected range |
+| assertion               | description                                                                    |
+|-------------------------|--------------------------------------------------------------------------------|
+| is_empty                | verify that a string is empty                                                  |                                                 
+| is_not_empty            | verify that a string is not empty                                              |
+| has_length              | verify that a string has exactly the expected length                           |                                                 
+| has_length_in_range     | verify that a string has a length that is in the expected range                |
+| has_length_less_than    | verify that a string has a length less than the expected length                |
+| has_length_greater_than | verify that a string has a length greater than the expected length             |
+| has_at_most_length      | verify that a string has a length less than or equal to the expected length    |
+| has_at_least_length     | verify that a string has a length greater than or equal to the expected length |
 
 for strings of type `OsString` and `OsStr` (requires crate feature `std`):
 
-| assertion           | description                                                     |
-|---------------------|-----------------------------------------------------------------|
-| is_empty            | verify that a string is empty                                   |                                                 
-| is_not_empty        | verify that a string is not empty                               |
-| has_length          | verify that a string has exactly the expected length            |                                                 
-| has_length_in_range | verify that a string has a length that is in the expected range |
+| assertion               | description                                                                    |
+|-------------------------|--------------------------------------------------------------------------------|
+| is_empty                | verify that a string is empty                                                  |                                                 
+| is_not_empty            | verify that a string is not empty                                              |
+| has_length              | verify that a string has exactly the expected length                           |                                                 
+| has_length_in_range     | verify that a string has a length that is in the expected range                |
+| has_length_less_than    | verify that a string has a length less than the expected length                |
+| has_length_greater_than | verify that a string has a length greater than the expected length             |
+| has_at_most_length      | verify that a string has a length less than or equal to the expected length    |
+| has_at_least_length     | verify that a string has a length greater than or equal to the expected length |
 
 ### Option
 
@@ -245,10 +257,14 @@ Implementing this property for any type enables these assertions for that type.
 
 for collections and strings.
 
-| assertion           | description                                                        |
-|---------------------|--------------------------------------------------------------------|
-| has_length          | verify that the subject has exactly the expected length            |                                                 
-| has_length_in_range | verify that the subject has a length that is in the expected range |
+| assertion               | description                                                                       |
+|-------------------------|-----------------------------------------------------------------------------------|
+| has_length              | verify that the subject has exactly the expected length                           |                                                 
+| has_length_in_range     | verify that the subject has a length that is in the expected range                |
+| has_length_less_than    | verify that the subject has a length less than the expected length                |
+| has_length_greater_than | verify that the subject has a length greater than the expected length             |
+| has_at_most_length      | verify that the subject has a length less than or equal to the expected length    |
+| has_at_least_length     | verify that the subject has a length greater than or equal to the expected length |
 
 The implementation of these assertions is based on the property trait [`LengthProperty`].
 Implementing this property for any type enables these assertions for that type.

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -284,12 +284,23 @@ pub trait AssertEmptiness {
 ///
 /// let some_str = "takimata te iriure nonummy";
 /// assert_that!(some_str).has_length(26);
+/// assert_that!(some_str).has_length_in_range(12..=32);
+/// assert_that!(some_str).has_length_less_than(27);
+/// assert_that!(some_str).has_length_greater_than(25);
+/// assert_that!(some_str).has_at_most_length(26);
+/// assert_that!(some_str).has_at_most_length(30);
+/// assert_that!(some_str).has_at_least_length(26);
+/// assert_that!(some_str).has_at_least_length(20);
 ///
-/// let some_array = [12, 24, 36, 48];
-/// assert_that!(some_array).has_length(4);
-///
-/// let some_slice: &[_] = &['a', 'b', 'c'][..];
-/// assert_that!(some_slice).has_length(3);
+/// let some_vec = vec!['m', 'Q', 'k', 'b'];
+/// assert_that!(&some_vec).has_length(4);
+/// assert_that!(&some_vec).has_length_in_range(2..=6);
+/// assert_that!(&some_vec).has_length_less_than(5);
+/// assert_that!(&some_vec).has_length_greater_than(3);
+/// assert_that!(&some_vec).has_at_most_length(4);
+/// assert_that!(&some_vec).has_at_most_length(10);
+/// assert_that!(&some_vec).has_at_least_length(4);
+/// assert_that!(&some_vec).has_at_least_length(1);
 ///
 /// let some_btree_set = BTreeSet::from_iter([1, 3, 5, 7, 11, 13, 17, 19]);
 /// assert_that!(some_btree_set).has_length(8);
@@ -319,13 +330,35 @@ pub trait AssertEmptiness {
 pub trait AssertHasLength<E> {
     /// Verifies that the subject has the expected length.
     #[track_caller]
-    fn has_length(self, expected: E) -> Self;
+    fn has_length(self, expected_length: E) -> Self;
 
     /// Verifies that the subject has a length in the expected range.
     ///
     /// The expected range must be a closed range with both ends inclusive.
     #[track_caller]
-    fn has_length_in_range(self, range: RangeInclusive<E>) -> Self;
+    fn has_length_in_range(self, expected_range: RangeInclusive<E>) -> Self;
+
+    /// Verifies that the subject has a length that is less than the expected
+    /// length.
+    fn has_length_less_than(self, expected_length: E) -> Self;
+
+    /// Verifies that the subject has a length that is greater than the expected
+    /// length.
+    fn has_length_greater_than(self, expected_length: E) -> Self;
+
+    /// Verifies that the subject has a length that is at most the expected
+    /// length.
+    ///
+    /// In other words, the length shall be less than or equal to the expected
+    /// length.
+    fn has_at_most_length(self, expected_length: E) -> Self;
+
+    /// Verifies that the subject has a length that is at least the expected
+    /// length.
+    ///
+    /// In other words, the length shall be greater than or equal to the
+    /// expected length.
+    fn has_at_least_length(self, expected_length: E) -> Self;
 }
 
 /// Assert the number of characters contained in a string or similar container.

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -373,13 +373,21 @@ pub trait AssertHasLength<E> {
 /// use asserting::prelude::*;
 ///
 /// let subject = "imper \u{0180} diet al \u{02AA} \u{01AF} zzril";
-/// assert_that(subject).has_length(28);
-/// assert_that(subject).has_char_count(25);
-/// assert_that(subject).has_char_count_in_range(12..=36);
+/// assert_that!(subject).has_length(28);
+/// assert_that!(subject).has_char_count(25);
 ///
 /// let subject = "imper diet al zzril";
-/// assert_that(subject).has_length(19);
-/// assert_that(subject).has_char_count(19);
+/// assert_that!(subject).has_length(19);
+/// assert_that!(subject).has_char_count(19);
+///
+/// let subject = "imper \u{0180} diet al \u{02AA} \u{01AF} zzril";
+/// assert_that!(subject).has_char_count_in_range(12..=36);
+/// assert_that!(subject).has_char_count_less_than(26);
+/// assert_that!(subject).has_char_count_greater_than(24);
+/// assert_that!(subject).has_at_most_char_count(26);
+/// assert_that!(subject).has_at_most_char_count(30);
+/// assert_that!(subject).has_at_least_char_count(25);
+/// assert_that!(subject).has_at_least_char_count(20);
 /// ```
 pub trait AssertHasCharCount<E> {
     /// Verifies that the subject contains the expected number of characters.
@@ -392,6 +400,32 @@ pub trait AssertHasCharCount<E> {
     /// The expected range must be a closed range with both ends inclusive.
     #[track_caller]
     fn has_char_count_in_range(self, range: RangeInclusive<E>) -> Self;
+
+    /// Verifies that the subject contains less than the expected number of
+    /// characters.
+    #[track_caller]
+    fn has_char_count_less_than(self, expected: E) -> Self;
+
+    /// Verifies that the subject contains more than the expected number of
+    /// characters.
+    #[track_caller]
+    fn has_char_count_greater_than(self, expected: E) -> Self;
+
+    /// Verifies that the subject contains at least the expected number of
+    /// characters.
+    ///
+    /// In other words, the number of characters shall be less than or equal
+    /// to the expected number.
+    #[track_caller]
+    fn has_at_most_char_count(self, expected: E) -> Self;
+
+    /// Verifies that the subject contains at least the expected number of
+    /// characters.
+    ///
+    /// In other words, the number of characters shall be greater than or equal
+    /// to the expected number.
+    #[track_caller]
+    fn has_at_least_char_count(self, expected: E) -> Self;
 }
 
 /// Assert whether a subject of the `Option` type holds some value or has none.

--- a/src/char_count.rs
+++ b/src/char_count.rs
@@ -2,7 +2,10 @@
 
 use crate::assertions::AssertHasCharCount;
 use crate::colored::{mark_missing, mark_unexpected};
-use crate::expectations::{HasCharCount, HasCharCountInRange};
+use crate::expectations::{
+    HasAtLeastCharCount, HasAtMostCharCount, HasCharCount, HasCharCountGreaterThan,
+    HasCharCountInRange, HasCharCountLessThan,
+};
 use crate::properties::CharCountProperty;
 use crate::spec::{DiffFormat, Expectation, Expression, FailingStrategy, Spec};
 use crate::std::fmt::Debug;
@@ -15,15 +18,39 @@ where
     S: CharCountProperty + Debug,
     R: FailingStrategy,
 {
-    fn has_char_count(self, expected: usize) -> Self {
+    fn has_char_count(self, expected_char_count: usize) -> Self {
         self.expecting(HasCharCount {
-            expected_char_count: expected,
+            expected_char_count,
         })
     }
 
     fn has_char_count_in_range(self, range: RangeInclusive<usize>) -> Self {
         self.expecting(HasCharCountInRange {
             expected_range: range,
+        })
+    }
+
+    fn has_char_count_less_than(self, expected_char_count: usize) -> Self {
+        self.expecting(HasCharCountLessThan {
+            expected_char_count,
+        })
+    }
+
+    fn has_char_count_greater_than(self, expected_char_count: usize) -> Self {
+        self.expecting(HasCharCountGreaterThan {
+            expected_char_count,
+        })
+    }
+
+    fn has_at_most_char_count(self, expected_char_count: usize) -> Self {
+        self.expecting(HasAtMostCharCount {
+            expected_char_count,
+        })
+    }
+
+    fn has_at_least_char_count(self, expected_char_count: usize) -> Self {
+        self.expecting(HasAtLeastCharCount {
+            expected_char_count,
         })
     }
 }
@@ -60,6 +87,78 @@ where
         format!(
             "expected {expression} has a char count of {:?}\n   but was: {marked_actual}\n  expected: {marked_expected}",
             self.expected_range,
+        )
+    }
+}
+
+impl<S> Expectation<S> for HasCharCountLessThan<usize>
+where
+    S: CharCountProperty + Debug,
+{
+    fn test(&mut self, subject: &S) -> bool {
+        subject.char_count_property() < self.expected_char_count
+    }
+
+    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+        let marked_actual = mark_unexpected(&actual.char_count_property(), format);
+        let marked_expected = mark_missing(&self.expected_char_count, format);
+        format!(
+            "expected {expression} has a char count less than {:?}\n   but was: {marked_actual}\n  expected: < {marked_expected}",
+            self.expected_char_count,
+        )
+    }
+}
+
+impl<S> Expectation<S> for HasCharCountGreaterThan<usize>
+where
+    S: CharCountProperty + Debug,
+{
+    fn test(&mut self, subject: &S) -> bool {
+        subject.char_count_property() > self.expected_char_count
+    }
+
+    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+        let marked_actual = mark_unexpected(&actual.char_count_property(), format);
+        let marked_expected = mark_missing(&self.expected_char_count, format);
+        format!(
+            "expected {expression} has a char count greater than {:?}\n   but was: {marked_actual}\n  expected: > {marked_expected}",
+            self.expected_char_count,
+        )
+    }
+}
+
+impl<S> Expectation<S> for HasAtMostCharCount<usize>
+where
+    S: CharCountProperty + Debug,
+{
+    fn test(&mut self, subject: &S) -> bool {
+        subject.char_count_property() <= self.expected_char_count
+    }
+
+    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+        let marked_actual = mark_unexpected(&actual.char_count_property(), format);
+        let marked_expected = mark_missing(&self.expected_char_count, format);
+        format!(
+            "expected {expression} has at most a char count of {:?}\n   but was: {marked_actual}\n  expected: <= {marked_expected}",
+            self.expected_char_count,
+        )
+    }
+}
+
+impl<S> Expectation<S> for HasAtLeastCharCount<usize>
+where
+    S: CharCountProperty,
+{
+    fn test(&mut self, subject: &S) -> bool {
+        subject.char_count_property() >= self.expected_char_count
+    }
+
+    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+        let marked_actual = mark_unexpected(&actual.char_count_property(), format);
+        let marked_expected = mark_missing(&self.expected_char_count, format);
+        format!(
+            "expected {expression} has at least a char count of {:?}\n   but was: {marked_actual}\n  expected: >= {marked_expected}",
+            self.expected_char_count,
         )
     }
 }

--- a/src/expectations.rs
+++ b/src/expectations.rs
@@ -142,6 +142,26 @@ pub struct HasLengthInRange<E> {
 }
 
 #[must_use]
+pub struct HasLengthLessThan<E> {
+    pub expected_length: E,
+}
+
+#[must_use]
+pub struct HasLengthGreaterThan<E> {
+    pub expected_length: E,
+}
+
+#[must_use]
+pub struct HasAtMostLength<E> {
+    pub expected_length: E,
+}
+
+#[must_use]
+pub struct HasAtLeastLength<E> {
+    pub expected_length: E,
+}
+
+#[must_use]
 pub struct HasCharCount<E> {
     pub expected_char_count: E,
 }

--- a/src/expectations.rs
+++ b/src/expectations.rs
@@ -172,6 +172,26 @@ pub struct HasCharCountInRange<E> {
 }
 
 #[must_use]
+pub struct HasCharCountLessThan<E> {
+    pub expected_char_count: E,
+}
+
+#[must_use]
+pub struct HasCharCountGreaterThan<E> {
+    pub expected_char_count: E,
+}
+
+#[must_use]
+pub struct HasAtMostCharCount<E> {
+    pub expected_char_count: E,
+}
+
+#[must_use]
+pub struct HasAtLeastCharCount<E> {
+    pub expected_char_count: E,
+}
+
+#[must_use]
 pub struct StringContains<E> {
     pub expected: E,
 }

--- a/src/length.rs
+++ b/src/length.rs
@@ -2,7 +2,10 @@
 
 use crate::assertions::{AssertEmptiness, AssertHasLength};
 use crate::colored::{mark_missing, mark_unexpected};
-use crate::expectations::{HasLength, HasLengthInRange, IsEmpty, IsNotEmpty};
+use crate::expectations::{
+    HasAtLeastLength, HasAtMostLength, HasLength, HasLengthGreaterThan, HasLengthInRange,
+    HasLengthLessThan, IsEmpty, IsNotEmpty,
+};
 use crate::properties::{IsEmptyProperty, LengthProperty};
 use crate::spec::{DiffFormat, Expectation, Expression, FailingStrategy, Spec};
 use crate::std::fmt::Debug;
@@ -67,6 +70,22 @@ where
             expected_range: range,
         })
     }
+
+    fn has_length_less_than(self, expected_length: usize) -> Self {
+        self.expecting(HasLengthLessThan { expected_length })
+    }
+
+    fn has_length_greater_than(self, expected_length: usize) -> Self {
+        self.expecting(HasLengthGreaterThan { expected_length })
+    }
+
+    fn has_at_most_length(self, expected_length: usize) -> Self {
+        self.expecting(HasAtMostLength { expected_length })
+    }
+
+    fn has_at_least_length(self, expected_length: usize) -> Self {
+        self.expecting(HasAtLeastLength { expected_length })
+    }
 }
 
 impl<S> Expectation<S> for HasLength<usize>
@@ -101,6 +120,78 @@ where
         format!(
             "expected {expression} has length in range {:?}\n   but was: {marked_actual}\n  expected: {marked_expected}",
             self.expected_range,
+        )
+    }
+}
+
+impl<S> Expectation<S> for HasLengthLessThan<usize>
+where
+    S: LengthProperty + Debug,
+{
+    fn test(&mut self, subject: &S) -> bool {
+        subject.length_property() < self.expected_length
+    }
+
+    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+        let marked_actual = mark_unexpected(&actual.length_property(), format);
+        let marked_expected = mark_missing(&self.expected_length, format);
+        format!(
+            "expected {expression} has a length less than {:?}\n   but was: {marked_actual}\n  expected: < {marked_expected}",
+            self.expected_length,
+        )
+    }
+}
+
+impl<S> Expectation<S> for HasLengthGreaterThan<usize>
+where
+    S: LengthProperty + Debug,
+{
+    fn test(&mut self, subject: &S) -> bool {
+        subject.length_property() > self.expected_length
+    }
+
+    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+        let marked_actual = mark_unexpected(&actual.length_property(), format);
+        let marked_expected = mark_missing(&self.expected_length, format);
+        format!(
+            "expected {expression} has a length greater than {:?}\n   but was: {marked_actual}\n  expected: > {marked_expected}",
+            self.expected_length,
+        )
+    }
+}
+
+impl<S> Expectation<S> for HasAtMostLength<usize>
+where
+    S: LengthProperty + Debug,
+{
+    fn test(&mut self, subject: &S) -> bool {
+        subject.length_property() <= self.expected_length
+    }
+
+    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+        let marked_actual = mark_unexpected(&actual.length_property(), format);
+        let marked_expected = mark_missing(&self.expected_length, format);
+        format!(
+            "expected {expression} has at most a length of {:?}\n   but was: {marked_actual}\n  expected: <= {marked_expected}",
+            self.expected_length,
+        )
+    }
+}
+
+impl<S> Expectation<S> for HasAtLeastLength<usize>
+where
+    S: LengthProperty + Debug,
+{
+    fn test(&mut self, subject: &S) -> bool {
+        subject.length_property() >= self.expected_length
+    }
+
+    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+        let marked_actual = mark_unexpected(&actual.length_property(), format);
+        let marked_expected = mark_missing(&self.expected_length, format);
+        format!(
+            "expected {expression} has at least a length of {:?}\n   but was: {marked_actual}\n  expected: >= {marked_expected}",
+            self.expected_length,
         )
     }
 }

--- a/src/slice/tests.rs
+++ b/src/slice/tests.rs
@@ -69,6 +69,116 @@ fn slice_has_length_in_range() {
 }
 
 #[test]
+fn slice_has_length_less_than() {
+    let subject: &[i32] = &[5, 1, 3, 18, 11, 9];
+
+    assert_that(subject).has_length_less_than(7);
+}
+
+#[test]
+fn verify_slice_has_length_less_than_fails() {
+    let subject: &[i32] = &[5, 1, 3, 18, 11, 9];
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .has_length_less_than(6)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing has a length less than 6
+   but was: 6
+  expected: < 6
+"
+        ]
+    );
+}
+
+#[test]
+fn slice_has_length_greater_than() {
+    let subject: &[i32] = &[5, 1, 3, 18, 11, 9];
+
+    assert_that(subject).has_length_greater_than(5);
+}
+
+#[test]
+fn verify_slice_has_length_greater_than_fails() {
+    let subject: &[i32] = &[5, 1, 3, 18, 11, 9];
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .has_length_greater_than(6)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing has a length greater than 6
+   but was: 6
+  expected: > 6
+"
+        ]
+    );
+}
+
+#[test]
+fn slice_has_at_most_length() {
+    let subject: &[i32] = &[5, 1, 3, 18, 11, 9];
+
+    assert_that(&subject).has_at_most_length(6);
+    assert_that(subject).has_at_most_length(7);
+}
+
+#[test]
+fn verify_slice_has_at_most_length_fails() {
+    let subject: &[i32] = &[5, 1, 3, 18, 11, 9];
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .has_at_most_length(5)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing has at most a length of 5
+   but was: 6
+  expected: <= 5
+"
+        ]
+    );
+}
+
+#[test]
+fn slice_has_at_least_length() {
+    let subject: &[i32] = &[5, 1, 3, 18, 11, 9];
+
+    assert_that(&subject).has_at_least_length(6);
+    assert_that(subject).has_at_least_length(5);
+}
+
+#[test]
+fn verify_slice_has_at_least_length_fails() {
+    let subject: &[i32] = &[5, 1, 3, 18, 11, 9];
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .has_at_least_length(7)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing has at least a length of 7
+   but was: 6
+  expected: >= 7
+"
+        ]
+    );
+}
+
+#[test]
 fn slice_contains() {
     let subject: &[i32] = &[1, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43];
 

--- a/src/string/tests.rs
+++ b/src/string/tests.rs
@@ -437,6 +437,116 @@ fn verify_str_has_char_count_in_range_fails() {
 }
 
 #[test]
+fn string_has_char_count_less_than() {
+    let subject: String = "\u{0112} \u{0034} \u{0200} \u{01BE}".to_string();
+
+    assert_that(subject).has_char_count_less_than(8);
+}
+
+#[test]
+fn verify_string_has_char_count_less_than_fails() {
+    let subject: String = "\u{0112} \u{0034} \u{0200} \u{01BE}".to_string();
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .has_char_count_less_than(7)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing has a char count less than 7
+   but was: 7
+  expected: < 7
+"
+        ]
+    );
+}
+
+#[test]
+fn string_has_char_count_greater_than() {
+    let subject: String = "\u{0112} \u{0034} \u{0200} \u{01BE}".to_string();
+
+    assert_that(subject).has_char_count_greater_than(6);
+}
+
+#[test]
+fn verify_string_has_char_count_greater_than_fails() {
+    let subject: String = "\u{0112} \u{0034} \u{0200} \u{01BE}".to_string();
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .has_char_count_greater_than(7)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing has a char count greater than 7
+   but was: 7
+  expected: > 7
+"
+        ]
+    );
+}
+
+#[test]
+fn string_has_at_most_char_count() {
+    let subject: String = "\u{0112} \u{0034} \u{0200} \u{01BE}".to_string();
+
+    assert_that(&subject).has_at_most_char_count(7);
+    assert_that(subject).has_at_most_char_count(8);
+}
+
+#[test]
+fn verify_string_has_at_most_char_count_fails() {
+    let subject: String = "\u{0112} \u{0034} \u{0200} \u{01BE}".to_string();
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .has_at_most_char_count(6)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing has at most a char count of 6
+   but was: 7
+  expected: <= 6
+"
+        ]
+    );
+}
+
+#[test]
+fn string_has_at_least_char_count() {
+    let subject: String = "\u{0112} \u{0034} \u{0200} \u{01BE}".to_string();
+
+    assert_that(&subject).has_at_least_char_count(7);
+    assert_that(subject).has_at_least_char_count(6);
+}
+
+#[test]
+fn verify_string_has_at_least_char_count_fails() {
+    let subject: String = "\u{0112} \u{0034} \u{0200} \u{01BE}".to_string();
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .has_at_least_char_count(8)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing has at least a char count of 8
+   but was: 7
+  expected: >= 8
+"
+        ]
+    );
+}
+
+#[test]
 fn string_contains_other_str() {
     let subject: String = "illum kasd nostrud possim".to_string();
 

--- a/src/string/tests.rs
+++ b/src/string/tests.rs
@@ -236,6 +236,116 @@ fn verify_has_length_in_range_fails() {
 }
 
 #[test]
+fn string_has_length_less_than() {
+    let subject: String = "congue veniam et proident".to_string();
+
+    assert_that(subject).has_length_less_than(26);
+}
+
+#[test]
+fn verify_string_has_length_less_than_fails() {
+    let subject: String = "congue veniam et proident".to_string();
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .has_length_less_than(25)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing has a length less than 25
+   but was: 25
+  expected: < 25
+"
+        ]
+    );
+}
+
+#[test]
+fn string_has_length_greater_than() {
+    let subject: String = "deserunt elit aliquip eirmod".to_string();
+
+    assert_that(subject).has_length_greater_than(27);
+}
+
+#[test]
+fn verify_string_has_length_greater_than_fails() {
+    let subject: String = "deserunt elit aliquip eirmod".to_string();
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .has_length_greater_than(28)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing has a length greater than 28
+   but was: 28
+  expected: > 28
+"
+        ]
+    );
+}
+
+#[test]
+fn string_has_at_most_length() {
+    let subject: String = "facilisi euismod veniam labore".to_string();
+
+    assert_that(&subject).has_at_most_length(30);
+    assert_that(subject).has_at_most_length(31);
+}
+
+#[test]
+fn verify_string_has_at_most_length_fails() {
+    let subject: String = "facilisi euismod veniam labore".to_string();
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .has_at_most_length(29)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing has at most a length of 29
+   but was: 30
+  expected: <= 29
+"
+        ]
+    );
+}
+
+#[test]
+fn string_has_at_least_length() {
+    let subject: String = "autem in option zzril".to_string();
+
+    assert_that(&subject).has_at_least_length(21);
+    assert_that(subject).has_at_least_length(20);
+}
+
+#[test]
+fn verify_string_has_at_least_length_fails() {
+    let subject: String = "autem in option zzril".to_string();
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .has_at_least_length(22)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing has at least a length of 22
+   but was: 21
+  expected: >= 22
+"
+        ]
+    );
+}
+
+#[test]
 fn string_has_char_count() {
     let subject: String = "option\u{0074}\u{02B0} sadipscing accusam augue".to_string();
 


### PR DESCRIPTION
It would be convenient to have additional assertions for length of strings and collections as well as additional assertions for char count of strings.

The addtiional length assertions `has_length_less_than`, `has_length_greater_than`, `has_at_most_length` and `has_at_least_length` have been implemented, as well as

the additional char count assertions `has_char_count_less_than`, has_char_count_greater_than`, `has_at_most_char_count` and `has_at_least_char_count` have been implemented.