### PR TITLE
fix!: rename crate feature `float` to `float_cmp`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features "colored, float"
+          args: --no-default-features --features "colored, float_cmp"
 
   msrv:
     name: Build with MSRV

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ categories = ["development-tools::testing", "no-std"]
 all-features = true
 
 [features]
-default = ["std", "colored", "float", "panic"]
+default = ["std", "colored", "float_cmp", "panic"]
 colored = ["dep:sdiff"]
-float = ["dep:float-cmp"]
+float_cmp = ["dep:float-cmp"]
 panic = ["std"]
 std = []
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ require std can still be added.
 
 ```toml
 [dev-dependencies]
-asserting = { version = "0.3", default-features = false, features = ["colored", "float"] }
+asserting = { version = "0.3", default-features = false, features = ["colored", "float_cmp"] }
 ```
 
 An allocator is still needed for no-std.
@@ -184,7 +184,7 @@ for floating point numbers of type `f32` and `f64`:
 
 for floating point numbers of type `f32` and `f64`.
 
-requires crate feature `float` which is enabled by default.
+requires crate feature `float_cmp` which is enabled by default.
 
 | assertion                   | description                                                                                      |
 |-----------------------------|--------------------------------------------------------------------------------------------------|

--- a/examples/fixture/mod.rs
+++ b/examples/fixture/mod.rs
@@ -2,7 +2,7 @@
 // Rust issue [#95513](https://github.com/rust-lang/rust/issues/95513) is fixed
 mod dummy_extern_uses {
     use anyhow as _;
-    #[cfg(feature = "float")]
+    #[cfg(feature = "float_cmp")]
     use float_cmp as _;
     use hashbrown as _;
     use proptest as _;

--- a/justfile
+++ b/justfile
@@ -37,7 +37,7 @@ lint-all-features:
 
 # linting code using Clippy for no-std environment
 lint-no-std:
-    cargo clippy --all-targets --no-default-features --features "colored, float"
+    cargo clippy --all-targets --no-default-features --features "colored, float_cmp"
 
 # linting code using Clippy with no features enabled
 lint-no-features:
@@ -55,7 +55,7 @@ test-all-features:
 
 # run tests for no-std environment
 test-no-std:
-    cargo test --no-default-features --features "colored, float"
+    cargo test --no-default-features --features "colored, float_cmp"
 
 # run tests with no features enabled
 test-no-features:

--- a/src/float/mod.rs
+++ b/src/float/mod.rs
@@ -71,7 +71,7 @@ impl IsNanProperty for f64 {
     }
 }
 
-#[cfg(feature = "float")]
+#[cfg(feature = "float_cmp")]
 mod cmp {
     use crate::assertions::{AssertIsCloseToWithDefaultMargin, AssertIsCloseToWithinMargin};
     use crate::colored::mark_diff;

--- a/src/float/tests.rs
+++ b/src/float/tests.rs
@@ -418,7 +418,7 @@ fn verify_f64_is_not_a_number_fails() {
     );
 }
 
-#[cfg(feature = "float")]
+#[cfg(feature = "float_cmp")]
 mod cmp {
     use crate::prelude::*;
 

--- a/src/spec/tests.rs
+++ b/src/spec/tests.rs
@@ -75,7 +75,7 @@ fn mapping_subject_in_spec() {
         .is_equal_to((12, -64));
 }
 
-#[cfg(feature = "float")]
+#[cfg(feature = "float_cmp")]
 #[test]
 fn extracting_from_subject_in_spec() {
     struct Foo {

--- a/tests/version_numbers.rs
+++ b/tests/version_numbers.rs
@@ -6,7 +6,7 @@
 mod dummy_extern_uses {
     use anyhow as _;
     use asserting as _;
-    #[cfg(feature = "float")]
+    #[cfg(feature = "float_cmp")]
     use float_cmp as _;
     use hashbrown as _;
     use proptest as _;


### PR DESCRIPTION
Assertions for floats are available without any crate feature enabled. The crate feature for floats that we need is for comparison of floating point numbers, i.e. the assertions `is_close_to` and `is_close_to_with_margin`. Therefore the name of the crate feature `float` may be missleading.

The crate feature `float` has been renamed to `float_cmp`.

BREAKING_CHANGE:

Projects that are using the crate feature `float` explicitly in their `Cargo.toml` must replace it with `float_cmp`.
The functionality of the crate feature is unchanged. So simple replacing `float` with `float_cmp` is safe.

