### PR TITLE
fix: old feature name in jetbrains run configurations

### DIFF
--- a/.ide-settings/jetbrains/runConfigurations/Clippy no-std.run.xml
+++ b/.ide-settings/jetbrains/runConfigurations/Clippy no-std.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Clippy no-std" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
-    <option name="command" value="clippy --all-targets --no-default-features --features &quot;colored, float&quot;" />
+    <option name="command" value="clippy --all-targets --no-default-features --features &quot;colored, float_cmp&quot;" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
     <option name="emulateTerminal" value="false" />

--- a/.ide-settings/jetbrains/runConfigurations/Test lib no-std.run.xml
+++ b/.ide-settings/jetbrains/runConfigurations/Test lib no-std.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Test lib no-std" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
     <option name="buildProfileId" value="test" />
-    <option name="command" value="test --lib --no-default-features --features &quot;colored, float&quot;" />
+    <option name="command" value="test --lib --no-default-features --features &quot;colored, float_cmp&quot;" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
     <option name="emulateTerminal" value="false" />

--- a/.ide-settings/jetbrains/runConfigurations/Test no-std.run.xml
+++ b/.ide-settings/jetbrains/runConfigurations/Test no-std.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Test no-std" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
     <option name="buildProfileId" value="test" />
-    <option name="command" value="test --no-default-features --features &quot;colored, float&quot;" />
+    <option name="command" value="test --no-default-features --features &quot;colored, float_cmp&quot;" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
     <option name="emulateTerminal" value="false" />


### PR DESCRIPTION
In the run configurations for Jetbrain`s IDEs the old feature name `float` is configured. It must be replaced with the new feature name `float_cmp`.

The feature name has been corrected for all run configurations.