### PR TITLE
feat: accept any type of range in range assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,10 @@ for all types that implement `PartialOrd<E>` with `E` being the type of the expe
 for all types `T` that implement `PartialOrd<E>` and `E` implementing `PartialOrd<T>` with `E`
 being the type of the expected value.
 
-| assertion       | description                                                          |
-|-----------------|----------------------------------------------------------------------|
-| is_in_range     | verify that the subject is in the expected range (closed range)      |                                                 
-| is_not_in_range | verify that the subject is not in the specified range (closed range) |
+| assertion       | description                                           |
+|-----------------|-------------------------------------------------------|
+| is_in_range     | verify that the subject is in the expected range      |                                                 
+| is_not_in_range | verify that the subject is not in the specified range |
 
 ### Integer and Float
 

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -11,7 +11,8 @@
 #![allow(clippy::wrong_self_convention, clippy::return_self_not_must_use)]
 
 use crate::spec::Spec;
-use crate::std::ops::RangeInclusive;
+use crate::std::fmt::Debug;
+use crate::std::ops::{RangeBounds, RangeInclusive};
 use crate::std::string::String;
 
 /// Assert whether two values are equal or not.
@@ -177,9 +178,18 @@ pub trait AssertOrder<E> {
     fn is_between(self, min: E, max: E) -> Self;
 }
 
+/// Common interface for supported range-like types.
+pub trait RangeLike<T> {
+    /// Returns true if this range contains the given value.
+    fn contains_value<E>(&self, value: &E) -> bool
+    where
+        T: PartialOrd<E>,
+        E: PartialOrd<T>;
+}
+
 /// Assert whether a value is within an expected range.
 ///
-/// The expected range must be a closed range with both ends inclusive.
+/// The expected range can be any of range.
 ///
 /// These assertions are implemented for all types `T` that implement
 /// `PartialOrd<E>` with `E` being the type of the expected value. And `E` must
@@ -190,23 +200,30 @@ pub trait AssertOrder<E> {
 /// ```
 /// use asserting::prelude::*;
 ///
-/// let some_char = 'M';
+/// assert_that!(7).is_in_range(6..8);
+/// assert_that!(8).is_not_in_range(6..8);
+/// assert_that!(1234).is_in_range(6..);
+/// assert_that!(5).is_not_in_range(6..);
+/// assert_that!(-33).is_in_range(..-1);
 ///
-/// assert_that!(some_char).is_in_range('A'..='Z');
-/// assert_that!(some_char).is_not_in_range('a'..='z');
+/// assert_that!('M').is_in_range('A'..='Z');
+/// assert_that!('M').is_not_in_range('a'..='z');
+/// assert_that!('k').is_in_range('h'..'n');
+/// assert_that!('r').is_in_range('H'..);
+/// assert_that!('N').is_in_range(..'n');
 /// ```
 pub trait AssertInRange<E> {
     /// Verifies that the subject is within the expected range.
-    ///
-    /// The expected range must be a closed range with both ends inclusive.
     #[track_caller]
-    fn is_in_range(self, range: RangeInclusive<E>) -> Self;
+    fn is_in_range<R>(self, range: R) -> Self
+    where
+        R: RangeBounds<E> + Debug;
 
     /// Verifies that the subject is not within the expected range.
-    ///
-    /// The expected range must be a closed range with both ends inclusive.
     #[track_caller]
-    fn is_not_in_range(self, range: RangeInclusive<E>) -> Self;
+    fn is_not_in_range<R>(self, range: R) -> Self
+    where
+        R: RangeBounds<E> + Debug;
 }
 
 /// Assert whether a numeric value is negative or positive.
@@ -304,7 +321,7 @@ pub trait AssertNumericIdentity {
 /// assert_that!(f64::NEG_INFINITY).is_negative().is_infinite();
 /// ```
 pub trait AssertInfinity {
-    /// Verifies that the subject is an infinite number.    
+    /// Verifies that the subject is an infinite number.
     #[track_caller]
     fn is_infinite(self) -> Self;
 

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -12,7 +12,7 @@
 
 use crate::spec::Spec;
 use crate::std::fmt::Debug;
-use crate::std::ops::{RangeBounds, RangeInclusive};
+use crate::std::ops::RangeBounds;
 use crate::std::string::String;
 
 /// Assert whether two values are equal or not.
@@ -462,7 +462,11 @@ pub trait AssertEmptiness {
 ///
 /// let some_str = "takimata te iriure nonummy";
 /// assert_that!(some_str).has_length(26);
+/// assert_that!(some_str).has_length_in_range(12..32);
 /// assert_that!(some_str).has_length_in_range(12..=32);
+/// assert_that!(some_str).has_length_in_range(12..);
+/// assert_that!(some_str).has_length_in_range(..32);
+/// assert_that!(some_str).has_length_in_range(..=32);
 /// assert_that!(some_str).has_length_less_than(27);
 /// assert_that!(some_str).has_length_greater_than(25);
 /// assert_that!(some_str).has_at_most_length(26);
@@ -472,7 +476,11 @@ pub trait AssertEmptiness {
 ///
 /// let some_vec = vec!['m', 'Q', 'k', 'b'];
 /// assert_that!(&some_vec).has_length(4);
+/// assert_that!(&some_vec).has_length_in_range(2..6);
 /// assert_that!(&some_vec).has_length_in_range(2..=6);
+/// assert_that!(&some_vec).has_length_in_range(2..);
+/// assert_that!(&some_vec).has_length_in_range(..6);
+/// assert_that!(&some_vec).has_length_in_range(..=6);
 /// assert_that!(&some_vec).has_length_less_than(5);
 /// assert_that!(&some_vec).has_length_greater_than(3);
 /// assert_that!(&some_vec).has_at_most_length(4);
@@ -512,9 +520,11 @@ pub trait AssertHasLength<E> {
 
     /// Verifies that the subject has a length in the expected range.
     ///
-    /// The expected range must be a closed range with both ends inclusive.
+    /// The expected range can be any type of range.
     #[track_caller]
-    fn has_length_in_range(self, expected_range: RangeInclusive<E>) -> Self;
+    fn has_length_in_range<U>(self, expected_range: U) -> Self
+    where
+        U: RangeBounds<usize> + Debug;
 
     /// Verifies that the subject has a length that is less than the expected
     /// length.
@@ -577,7 +587,9 @@ pub trait AssertHasCharCount<E> {
     ///
     /// The expected range must be a closed range with both ends inclusive.
     #[track_caller]
-    fn has_char_count_in_range(self, range: RangeInclusive<E>) -> Self;
+    fn has_char_count_in_range<U>(self, range: U) -> Self
+    where
+        U: RangeBounds<usize> + Debug;
 
     /// Verifies that the subject contains less than the expected number of
     /// characters.

--- a/src/char_count.rs
+++ b/src/char_count.rs
@@ -10,7 +10,7 @@ use crate::properties::CharCountProperty;
 use crate::spec::{DiffFormat, Expectation, Expression, FailingStrategy, Spec};
 use crate::std::fmt::Debug;
 use crate::std::format;
-use crate::std::ops::RangeInclusive;
+use crate::std::ops::RangeBounds;
 use crate::std::string::String;
 
 impl<S, R> AssertHasCharCount<usize> for Spec<'_, S, R>
@@ -24,10 +24,11 @@ where
         })
     }
 
-    fn has_char_count_in_range(self, range: RangeInclusive<usize>) -> Self {
-        self.expecting(HasCharCountInRange {
-            expected_range: range,
-        })
+    fn has_char_count_in_range<U>(self, expected_range: U) -> Self
+    where
+        U: RangeBounds<usize> + Debug,
+    {
+        self.expecting(HasCharCountInRange::new(expected_range))
     }
 
     fn has_char_count_less_than(self, expected_char_count: usize) -> Self {
@@ -73,9 +74,10 @@ where
     }
 }
 
-impl<S> Expectation<S> for HasCharCountInRange<usize>
+impl<S, R> Expectation<S> for HasCharCountInRange<R, usize>
 where
     S: CharCountProperty + Debug,
+    R: RangeBounds<usize> + Debug,
 {
     fn test(&mut self, subject: &S) -> bool {
         self.expected_range.contains(&subject.char_count_property())

--- a/src/expectations.rs
+++ b/src/expectations.rs
@@ -4,7 +4,6 @@
 #![warn(clippy::return_self_not_must_use)]
 
 use crate::std::marker::PhantomData;
-use crate::std::ops::RangeInclusive;
 use crate::std::{string::String, vec::Vec};
 use hashbrown::HashSet;
 
@@ -204,8 +203,18 @@ pub struct HasLength<E> {
 }
 
 #[must_use]
-pub struct HasLengthInRange<E> {
-    pub expected_range: RangeInclusive<E>,
+pub struct HasLengthInRange<R, E> {
+    pub expected_range: R,
+    _element_type: PhantomData<E>,
+}
+
+impl<R, E> HasLengthInRange<R, E> {
+    pub fn new(expected_range: R) -> Self {
+        Self {
+            expected_range,
+            _element_type: PhantomData,
+        }
+    }
 }
 
 #[must_use]
@@ -234,8 +243,18 @@ pub struct HasCharCount<E> {
 }
 
 #[must_use]
-pub struct HasCharCountInRange<E> {
-    pub expected_range: RangeInclusive<E>,
+pub struct HasCharCountInRange<R, E> {
+    pub expected_range: R,
+    _element_type: PhantomData<E>,
+}
+
+impl<R, E> HasCharCountInRange<R, E> {
+    pub fn new(expected_range: R) -> Self {
+        Self {
+            expected_range,
+            _element_type: PhantomData,
+        }
+    }
 }
 
 #[must_use]

--- a/src/expectations.rs
+++ b/src/expectations.rs
@@ -3,6 +3,7 @@
 #![allow(missing_docs)]
 #![warn(clippy::return_self_not_must_use)]
 
+use crate::std::marker::PhantomData;
 use crate::std::ops::RangeInclusive;
 use crate::std::{string::String, vec::Vec};
 use hashbrown::HashSet;
@@ -110,13 +111,33 @@ pub struct IsBetween<E> {
 }
 
 #[must_use]
-pub struct IsInRange<E> {
-    pub expected_range: RangeInclusive<E>,
+pub struct IsInRange<R, E> {
+    pub expected_range: R,
+    _element_type: PhantomData<E>,
+}
+
+impl<R, E> IsInRange<R, E> {
+    pub fn new(expected_range: R) -> Self {
+        Self {
+            expected_range,
+            _element_type: PhantomData,
+        }
+    }
 }
 
 #[must_use]
-pub struct IsNotInRange<E> {
-    pub expected_range: RangeInclusive<E>,
+pub struct IsNotInRange<R, E> {
+    pub expected_range: R,
+    _element_type: PhantomData<E>,
+}
+
+impl<R, E> IsNotInRange<R, E> {
+    pub fn new(expected_range: R) -> Self {
+        Self {
+            expected_range,
+            _element_type: PhantomData,
+        }
+    }
 }
 
 #[must_use]

--- a/src/length.rs
+++ b/src/length.rs
@@ -9,7 +9,7 @@ use crate::expectations::{
 use crate::properties::{IsEmptyProperty, LengthProperty};
 use crate::spec::{DiffFormat, Expectation, Expression, FailingStrategy, Spec};
 use crate::std::fmt::Debug;
-use crate::std::ops::RangeInclusive;
+use crate::std::ops::RangeBounds;
 use crate::std::{format, string::String};
 
 impl<S, R> AssertEmptiness for Spec<'_, S, R>
@@ -65,10 +65,11 @@ where
         self.expecting(HasLength { expected_length })
     }
 
-    fn has_length_in_range(self, range: RangeInclusive<usize>) -> Self {
-        self.expecting(HasLengthInRange {
-            expected_range: range,
-        })
+    fn has_length_in_range<U>(self, expected_range: U) -> Self
+    where
+        U: RangeBounds<usize> + Debug,
+    {
+        self.expecting(HasLengthInRange::new(expected_range))
     }
 
     fn has_length_less_than(self, expected_length: usize) -> Self {
@@ -106,9 +107,10 @@ where
     }
 }
 
-impl<S> Expectation<S> for HasLengthInRange<usize>
+impl<S, R> Expectation<S> for HasLengthInRange<R, usize>
 where
     S: LengthProperty + Debug,
+    R: RangeBounds<usize> + Debug,
 {
     fn test(&mut self, subject: &S) -> bool {
         self.expected_range.contains(&subject.length_property())

--- a/src/range/tests.rs
+++ b/src/range/tests.rs
@@ -8,11 +8,38 @@ use crate::prelude::*;
 fn i32_is_in_range() {
     let subject = 42;
 
-    assert_that(subject).is_in_range(41..=43);
+    assert_that(subject).is_in_range(41..43);
 }
 
 #[test]
 fn verify_i32_is_in_range_fails() {
+    let subject = 42;
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .is_in_range(43..51)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing is within range of 43..51
+   but was: 42
+  expected: 43 <= x < 51
+"
+        ]
+    );
+}
+
+#[test]
+fn i32_is_in_inclusive_range() {
+    let subject = 42;
+
+    assert_that(subject).is_in_range(41..=43);
+}
+
+#[test]
+fn verify_i32_is_in_inclusive_range_fails() {
     let subject = 42;
 
     let failures = verify_that(subject)
@@ -32,6 +59,87 @@ fn verify_i32_is_in_range_fails() {
 }
 
 #[test]
+fn i32_is_in_range_from() {
+    let subject = 42;
+
+    assert_that(subject).is_in_range(41..);
+}
+
+#[test]
+fn verify_i32_is_in_range_from_fails() {
+    let subject = 42;
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .is_in_range(43..)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing is within range of 43..
+   but was: 42
+  expected: 43 <= x < ..
+"
+        ]
+    );
+}
+
+#[test]
+fn i32_is_in_range_to() {
+    let subject = 42;
+
+    assert_that(subject).is_in_range(..43);
+}
+
+#[test]
+fn verify_i32_is_in_range_to_fails() {
+    let subject = 42;
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .is_in_range(..42)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing is within range of ..42
+   but was: 42
+  expected: .. < x < 42
+"
+        ]
+    );
+}
+
+#[test]
+fn i32_is_in_range_to_inclusive() {
+    let subject = 42;
+
+    assert_that(subject).is_in_range(..=42);
+}
+
+#[test]
+fn verify_i32_is_in_range_to_inclusive_fails() {
+    let subject = 42;
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .is_in_range(..=41)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing is within range of ..=41
+   but was: 42
+  expected: .. < x <= 41
+"
+        ]
+    );
+}
+
+#[test]
 fn i32_is_not_in_range() {
     let subject = 42;
 
@@ -40,6 +148,33 @@ fn i32_is_not_in_range() {
 
 #[test]
 fn verify_i32_is_not_in_range_fails() {
+    let subject = 42;
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .is_not_in_range(41..43)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing is not within range of 41..43
+   but was: 42
+  expected: x < 41 || x >= 43
+"
+        ]
+    );
+}
+
+#[test]
+fn i32_is_not_in_inclusive_range() {
+    let subject = 42;
+
+    assert_that(subject).is_not_in_range(39..=41);
+}
+
+#[test]
+fn verify_i32_is_not_in_inclusive_range_fails() {
     let subject = 42;
 
     let failures = verify_that(subject)
@@ -58,6 +193,87 @@ fn verify_i32_is_not_in_range_fails() {
     );
 }
 
+#[test]
+fn i32_is_not_in_range_from() {
+    let subject = 38;
+
+    assert_that(subject).is_not_in_range(39..);
+}
+
+#[test]
+fn verify_i32_is_not_in_range_from_fails() {
+    let subject = 42;
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .is_not_in_range(42..)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing is not within range of 42..
+   but was: 42
+  expected: x < 42 || x > ..
+"
+        ]
+    );
+}
+
+#[test]
+fn i32_is_not_in_range_to() {
+    let subject = 42;
+
+    assert_that(subject).is_not_in_range(..42);
+}
+
+#[test]
+fn verify_i32_is_not_in_range_to_fails() {
+    let subject = 42;
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .is_not_in_range(..43)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing is not within range of ..43
+   but was: 42
+  expected: x < .. || x >= 43
+"
+        ]
+    );
+}
+
+#[test]
+fn i32_is_not_in_range_to_inclusive() {
+    let subject = 42;
+
+    assert_that(subject).is_not_in_range(..=41);
+}
+
+#[test]
+fn verify_i32_is_not_in_range_to_inclusive_fails() {
+    let subject = 42;
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .is_not_in_range(..=42)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing is not within range of ..=42
+   but was: 42
+  expected: x < .. || x > 42
+"
+        ]
+    );
+}
+
 //
 // Is in range for `char`
 //
@@ -66,11 +282,38 @@ fn verify_i32_is_not_in_range_fails() {
 fn char_is_in_range() {
     let subject = 'K';
 
-    assert_that(subject).is_in_range('J'..='L');
+    assert_that(subject).is_in_range('J'..'L');
 }
 
 #[test]
 fn verify_char_is_in_range_fails() {
+    let subject = 'K';
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .is_in_range('L'..'Z')
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing is within range of 'L'..'Z'
+   but was: 'K'
+  expected: 'L' <= x < 'Z'
+"
+        ]
+    );
+}
+
+#[test]
+fn char_is_in_inclusive_range() {
+    let subject = 'K';
+
+    assert_that(subject).is_in_range('J'..='L');
+}
+
+#[test]
+fn verify_char_is_in_inclusive_range_fails() {
     let subject = 'K';
 
     let failures = verify_that(subject)
@@ -98,6 +341,33 @@ fn char_is_not_in_range() {
 
 #[test]
 fn verify_char_is_not_in_range_fails() {
+    let subject = 'K';
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .is_not_in_range('J'..'L')
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing is not within range of 'J'..'L'
+   but was: 'K'
+  expected: x < 'J' || x >= 'L'
+"
+        ]
+    );
+}
+
+#[test]
+fn char_is_not_in_inclusive_range() {
+    let subject = 'K';
+
+    assert_that(subject).is_not_in_range('A'..='J');
+}
+
+#[test]
+fn verify_char_is_not_in_inclusive_range_fails() {
     let subject = 'K';
 
     let failures = verify_that(subject)
@@ -159,6 +429,46 @@ mod colored {
 
         let failures = verify_that(subject)
             .with_diff_format(DIFF_FORMAT_RED_BLUE)
+            .is_in_range(-4321..4322)
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[
+                "assertion failed: expected subject is within range of -4321..4322\n   \
+                     but was: \u{1b}[31m29834\u{1b}[0m\n  \
+                    expected: -4321 <= x < \u{1b}[34m4322\u{1b}[0m\n\
+                "
+            ]
+        );
+    }
+
+    #[test]
+    fn highlight_diffs_i64_is_in_range_below_lower_bound() {
+        let subject = -29_834;
+
+        let failures = verify_that(subject)
+            .with_diff_format(DIFF_FORMAT_RED_BLUE)
+            .is_in_range(-4321..4322)
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[
+                "assertion failed: expected subject is within range of -4321..4322\n   \
+                     but was: \u{1b}[31m-29834\u{1b}[0m\n  \
+                    expected: \u{1b}[34m-4321\u{1b}[0m <= x < 4322\n\
+                "
+            ]
+        );
+    }
+
+    #[test]
+    fn highlight_diffs_i64_is_in_inclusive_range_above_upper_bound() {
+        let subject = 29_834;
+
+        let failures = verify_that(subject)
+            .with_diff_format(DIFF_FORMAT_RED_BLUE)
             .is_in_range(-4321..=4321)
             .display_failures();
 
@@ -174,7 +484,7 @@ mod colored {
     }
 
     #[test]
-    fn highlight_diffs_i64_is_in_range_below_lower_bound() {
+    fn highlight_diffs_i64_is_in_inclusive_range_below_lower_bound() {
         let subject = -29_834;
 
         let failures = verify_that(subject)
@@ -195,6 +505,26 @@ mod colored {
 
     #[test]
     fn highlight_diffs_char_is_not_in_range() {
+        let subject = 'm';
+
+        let failures = verify_that(subject)
+            .with_diff_format(DIFF_FORMAT_RED_GREEN)
+            .is_not_in_range('a'..'p')
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[
+                "assertion failed: expected subject is not within range of 'a'..'p'\n   \
+                     but was: \u{1b}[31m'm'\u{1b}[0m\n  \
+                    expected: x < \u{1b}[32m'a'\u{1b}[0m || x >= \u{1b}[32m'p'\u{1b}[0m\n\
+                "
+            ]
+        );
+    }
+
+    #[test]
+    fn highlight_diffs_char_is_not_in_inclusive_range() {
         let subject = 'm';
 
         let failures = verify_that(subject)

--- a/src/slice/tests.rs
+++ b/src/slice/tests.rs
@@ -65,6 +65,13 @@ fn slice_has_length() {
 fn slice_has_length_in_range() {
     let subject: &[i32] = &[1, 3, 5, 7, 11];
 
+    assert_that(subject).has_length_in_range(4..6);
+}
+
+#[test]
+fn slice_has_length_in_inclusive_range() {
+    let subject: &[i32] = &[1, 3, 5, 7, 11];
+
     assert_that(subject).has_length_in_range(4..=6);
 }
 

--- a/src/string/tests.rs
+++ b/src/string/tests.rs
@@ -212,11 +212,38 @@ fn verify_str_has_length_fails() {
 fn string_has_length_in_range() {
     let subject: String = "fugiat vero cillum dolore".to_string();
 
-    assert_that(subject).has_length_in_range(1..=25);
+    assert_that(subject).has_length_in_range(1..26);
 }
 
 #[test]
 fn verify_has_length_in_range_fails() {
+    let subject: String = "fugiat vero cillum dolore".to_string();
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .has_length_in_range(1..25)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing has length in range 1..25
+   but was: 25
+  expected: 1..25
+"
+        ]
+    );
+}
+
+#[test]
+fn string_has_length_in_inclusive_range() {
+    let subject: String = "fugiat vero cillum dolore".to_string();
+
+    assert_that(subject).has_length_in_range(1..=25);
+}
+
+#[test]
+fn verify_has_length_in_inclusive_range_fails() {
     let subject: String = "fugiat vero cillum dolore".to_string();
 
     let failures = verify_that(subject)
@@ -399,6 +426,13 @@ fn verify_str_has_char_count_fails() {
 fn string_has_char_count_in_range() {
     let subject: String = "\u{0112} \u{0034} \u{0200}".to_string();
 
+    assert_that(subject).has_char_count_in_range(5..6);
+}
+
+#[test]
+fn string_has_char_count_in_inclusive_range() {
+    let subject: String = "\u{0112} \u{0034} \u{0200}".to_string();
+
     assert_that(subject).has_char_count_in_range(5..=5);
 }
 
@@ -413,11 +447,38 @@ fn borrowed_string_has_char_count_in_range() {
 fn str_has_char_count_in_range() {
     let subject: &str = "\u{0112} \u{0034} \u{0200}";
 
-    assert_that(subject).has_char_count_in_range(5..=5);
+    assert_that(subject).has_char_count_in_range(5..6);
 }
 
 #[test]
 fn verify_str_has_char_count_in_range_fails() {
+    let subject: &str = "\u{0112} \u{0034} \u{0200}";
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .has_char_count_in_range(6..12)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing has a char count of 6..12
+   but was: 5
+  expected: 6..12
+"
+        ]
+    );
+}
+
+#[test]
+fn str_has_char_count_in_inclusive_range() {
+    let subject: &str = "\u{0112} \u{0034} \u{0200}";
+
+    assert_that(subject).has_char_count_in_range(5..=5);
+}
+
+#[test]
+fn verify_str_has_char_count_in_inclusive_range_fails() {
     let subject: &str = "\u{0112} \u{0034} \u{0200}";
 
     let failures = verify_that(subject)


### PR DESCRIPTION
Currently assertions that take a range as expected value support only `RangeInclusive`. This shall be enhanced to support more types of ranges.

The assertions `is_in_range`, `is_not_in_range`, `has_length_in_range` and `has_char_count_in_range` have been changed to support any type of range from the Rust core lib. More precisely, any type that implements `core::ops::RangeBounds` is now supported.