### PR TITLE
feat: provide `matches` regex assertion for strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,11 @@ categories = ["development-tools::testing", "no-std"]
 all-features = true
 
 [features]
-default = ["std", "colored", "float_cmp", "panic"]
+default = ["std", "colored", "float_cmp", "panic", "regex"]
 colored = ["dep:sdiff"]
 float_cmp = ["dep:float-cmp"]
 panic = ["std"]
+regex = ["dep:regex"]
 std = []
 
 [dependencies]
@@ -29,6 +30,7 @@ hashbrown = "0.15"
 
 # optional
 float-cmp = { version = "0.10", optional = true }
+regex = { version = "1", optional = true }
 sdiff = { version = "0.1", optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ for strings of type `String` and `str`:
 | starts_with                 | verify that a string starts with the expected substring or character           |
 | ends_with                   | verify that a string ends with the expected substring or character             |
 | contains_any_of             | verify that a string contains any character from a collection of `char`s       |
+| matches                     | verify that a string matches the given regex (requires `regex` feature)        |                                                 
 
 for strings of type `CString` and `CStr`:
 

--- a/examples/fixture/mod.rs
+++ b/examples/fixture/mod.rs
@@ -6,6 +6,8 @@ mod dummy_extern_uses {
     use float_cmp as _;
     use hashbrown as _;
     use proptest as _;
+    #[cfg(feature = "regex")]
+    use regex as _;
     #[cfg(feature = "colored")]
     use sdiff as _;
     use serial_test as _;

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -906,6 +906,41 @@ pub trait AssertStringContainsAnyOf<E> {
     fn contains_any_of(self, pattern: E) -> Self;
 }
 
+/// Assert that a string matches a regex pattern.
+///
+/// # Example
+///
+/// ```
+/// # #[cfg(not(feature = "regex"))]
+/// # fn main() {}
+/// # #[cfg(feature = "regex")]
+/// # fn main() {
+/// use asserting::prelude::*;
+///
+/// assert_that("tation odio placerat in").matches(r"\b\w{8}\b");
+/// # }
+/// ```
+#[cfg(feature = "regex")]
+#[cfg_attr(docsrs, doc(cfg(feature = "regex")))]
+pub trait AssertStringMatches {
+    /// Verifies that a string matches the given regex pattern.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # #[cfg(not(feature = "regex"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "regex")]
+    /// # fn main() {
+    /// use asserting::prelude::*;
+    ///
+    /// assert_that("tation odio placerat in").matches(r"\b\w{8}\b");
+    /// # }
+    /// ```
+    #[track_caller]
+    fn matches(self, regex_pattern: &str) -> Self;
+}
+
 /// Assert that an iterator or collection contains the expected value.
 ///
 /// This assertion is implemented for any collection or iterator of items that

--- a/src/expectations.rs
+++ b/src/expectations.rs
@@ -297,6 +297,30 @@ pub struct StringEndsWith<E> {
     pub expected: E,
 }
 
+#[cfg(feature = "regex")]
+#[cfg_attr(docsrs, doc(cfg(feature = "regex")))]
+pub use regex::StringMatches;
+
+#[cfg(feature = "regex")]
+mod regex {
+    use regex::Regex;
+
+    #[must_use]
+    pub struct StringMatches<'a> {
+        pub pattern: &'a str,
+        pub regex: Result<Regex, regex::Error>,
+    }
+
+    impl<'a> StringMatches<'a> {
+        pub fn new(regex_pattern: &'a str) -> Self {
+            Self {
+                pattern: regex_pattern,
+                regex: Regex::new(regex_pattern),
+            }
+        }
+    }
+}
+
 #[must_use]
 pub struct IterContains<E> {
     pub expected: E,

--- a/tests/version_numbers.rs
+++ b/tests/version_numbers.rs
@@ -10,6 +10,8 @@ mod dummy_extern_uses {
     use float_cmp as _;
     use hashbrown as _;
     use proptest as _;
+    #[cfg(feature = "regex")]
+    use regex as _;
     #[cfg(feature = "colored")]
     use sdiff as _;
     use serial_test as _;


### PR DESCRIPTION
Implemented new assertion `matches` for strings. It verifies whether a string matches the given regex.

This assertion requires crate feature `regex` which is enabled by default.