### PR TITLE
refactor!: rename crate feature `float_cmp` to `float-cmp`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features "colored, float_cmp"
+          args: --no-default-features --features "colored, float-cmp"
 
   msrv:
     name: Build with MSRV

--- a/.ide-settings/jetbrains/runConfigurations/Clippy no-std.run.xml
+++ b/.ide-settings/jetbrains/runConfigurations/Clippy no-std.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Clippy no-std" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
-    <option name="command" value="clippy --all-targets --no-default-features --features &quot;colored, float_cmp&quot;" />
+    <option name="command" value="clippy --all-targets --no-default-features --features &quot;colored, float-cmp&quot;" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
     <option name="emulateTerminal" value="false" />

--- a/.ide-settings/jetbrains/runConfigurations/Test lib no-std.run.xml
+++ b/.ide-settings/jetbrains/runConfigurations/Test lib no-std.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Test lib no-std" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
     <option name="buildProfileId" value="test" />
-    <option name="command" value="test --lib --no-default-features --features &quot;colored, float_cmp&quot;" />
+    <option name="command" value="test --lib --no-default-features --features &quot;colored, float-cmp&quot;" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
     <option name="emulateTerminal" value="false" />

--- a/.ide-settings/jetbrains/runConfigurations/Test no-std.run.xml
+++ b/.ide-settings/jetbrains/runConfigurations/Test no-std.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Test no-std" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
     <option name="buildProfileId" value="test" />
-    <option name="command" value="test --no-default-features --features &quot;colored, float_cmp&quot;" />
+    <option name="command" value="test --no-default-features --features &quot;colored, float-cmp&quot;" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
     <option name="emulateTerminal" value="false" />

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["std", "colored", "float_cmp", "panic", "regex"]
+default = ["std", "colored", "float-cmp", "panic", "regex"]
 colored = ["dep:sdiff"]
-float_cmp = ["dep:float-cmp"]
+float-cmp = ["dep:float-cmp"]
 panic = ["std"]
 regex = ["dep:regex"]
 std = []

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ require std can still be added.
 
 ```toml
 [dev-dependencies]
-asserting = { version = "0.4", default-features = false, features = ["colored", "float_cmp"] }
+asserting = { version = "0.4", default-features = false, features = ["colored", "float-cmp"] }
 ```
 
 An allocator is still needed for no-std.
@@ -190,7 +190,7 @@ for floating point numbers of type `f32` and `f64`:
 
 for floating point numbers of type `f32` and `f64`.
 
-requires crate feature `float_cmp` which is enabled by default.
+requires crate feature `float-cmp` which is enabled by default.
 
 | assertion                   | description                                                                                      |
 |-----------------------------|--------------------------------------------------------------------------------------------------|

--- a/examples/fixture/mod.rs
+++ b/examples/fixture/mod.rs
@@ -2,7 +2,7 @@
 // Rust issue [#95513](https://github.com/rust-lang/rust/issues/95513) is fixed
 mod dummy_extern_uses {
     use anyhow as _;
-    #[cfg(feature = "float_cmp")]
+    #[cfg(feature = "float-cmp")]
     use float_cmp as _;
     use hashbrown as _;
     use proptest as _;

--- a/justfile
+++ b/justfile
@@ -37,7 +37,7 @@ lint-all-features:
 
 # linting code using Clippy for no-std environment
 lint-no-std:
-    cargo clippy --all-targets --no-default-features --features "colored, float_cmp"
+    cargo clippy --all-targets --no-default-features --features "colored, float-cmp"
 
 # linting code using Clippy with no features enabled
 lint-no-features:
@@ -55,7 +55,7 @@ test-all-features:
 
 # run tests for no-std environment
 test-no-std:
-    cargo test --no-default-features --features "colored, float_cmp"
+    cargo test --no-default-features --features "colored, float-cmp"
 
 # run tests with no features enabled
 test-no-features:

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -42,8 +42,8 @@ pub trait AssertEquality<E> {
 }
 
 /// Assert approximate equality for floating point numbers.
-#[cfg(feature = "float_cmp")]
-#[cfg_attr(docsrs, doc(cfg(feature = "float_cmp")))]
+#[cfg(feature = "float-cmp")]
+#[cfg_attr(docsrs, doc(cfg(feature = "float-cmp")))]
 pub trait AssertIsCloseToWithinMargin<E, M> {
     /// Verifies that the actual value is approximately equal to the expected
     /// value.
@@ -75,8 +75,8 @@ pub trait AssertIsCloseToWithinMargin<E, M> {
 }
 
 /// Assert approximate equality for floating point numbers.
-#[cfg(feature = "float_cmp")]
-#[cfg_attr(docsrs, doc(cfg(feature = "float_cmp")))]
+#[cfg(feature = "float-cmp")]
+#[cfg_attr(docsrs, doc(cfg(feature = "float-cmp")))]
 pub trait AssertIsCloseToWithDefaultMargin<E> {
     /// Verifies that the actual value is approximately equal to the expected
     /// value.

--- a/src/float/mod.rs
+++ b/src/float/mod.rs
@@ -71,7 +71,7 @@ impl IsNanProperty for f64 {
     }
 }
 
-#[cfg(feature = "float_cmp")]
+#[cfg(feature = "float-cmp")]
 mod cmp {
     use crate::assertions::{AssertIsCloseToWithDefaultMargin, AssertIsCloseToWithinMargin};
     use crate::colored::mark_diff;

--- a/src/float/tests.rs
+++ b/src/float/tests.rs
@@ -418,7 +418,7 @@ fn verify_f64_is_not_a_number_fails() {
     );
 }
 
-#[cfg(feature = "float_cmp")]
+#[cfg(feature = "float-cmp")]
 mod cmp {
     use crate::prelude::*;
 

--- a/src/spec/tests.rs
+++ b/src/spec/tests.rs
@@ -75,7 +75,7 @@ fn mapping_subject_in_spec() {
         .is_equal_to((12, -64));
 }
 
-#[cfg(feature = "float_cmp")]
+#[cfg(feature = "float-cmp")]
 #[test]
 fn extracting_from_subject_in_spec() {
     struct Foo {

--- a/tests/version_numbers.rs
+++ b/tests/version_numbers.rs
@@ -6,7 +6,7 @@
 mod dummy_extern_uses {
     use anyhow as _;
     use asserting as _;
-    #[cfg(feature = "float_cmp")]
+    #[cfg(feature = "float-cmp")]
     use float_cmp as _;
     use hashbrown as _;
     use proptest as _;


### PR DESCRIPTION
BREAKING-CHANGE:

the crate feature `float_cmp` has been renamed to `float-cmp`. The API and behavior is unchanged.

rename any occurrence of crate feature `float_cmp` to `float-cmp`.