### PR TITLE
refactor: read diff format configuration only once per test run

### DIFF
--- a/src/colored/mod.rs
+++ b/src/colored/mod.rs
@@ -43,6 +43,7 @@
 //! unexpected parts when composing the failure message for an assertion.
 //!
 //! [`NO_COLOR`]: https://no-color.org/
+
 #[cfg(feature = "colored")]
 #[cfg_attr(docsrs, doc(cfg(feature = "colored")))]
 pub use with_colored_feature::{

--- a/src/colored/tests.rs
+++ b/src/colored/tests.rs
@@ -96,137 +96,137 @@ mod with_colored_and_std_features {
 
     #[test]
     #[serial]
-    fn assert_that_sets_default_diff_format_env_var_not_set() {
+    fn get_configured_diff_format_when_env_var_not_set() {
         env::remove_var(ENV_VAR_HIGHLIGHT_DIFFS);
 
-        let assertion = assert_that(42);
+        let diff_format = configured_diff_format();
 
-        assert_that(assertion.diff_format()).is_equal_to(&DEFAULT_DIFF_FORMAT);
+        assert_that(diff_format).is_equal_to(DEFAULT_DIFF_FORMAT);
     }
 
     #[test]
     #[serial]
-    fn assert_that_sets_default_diff_format_env_var_not_set_no_color_env_var_set() {
+    fn get_configured_diff_format_when_env_var_not_set_and_no_color_env_var_set() {
         env::remove_var(ENV_VAR_HIGHLIGHT_DIFFS);
         env::set_var("NO_COLOR", "1");
 
-        let assertion = assert_that(42);
+        let diff_format = configured_diff_format();
 
         env::remove_var("NO_COLOR");
 
-        assert_that(assertion.diff_format()).is_equal_to(&DIFF_FORMAT_NO_HIGHLIGHT);
+        assert_that(diff_format).is_equal_to(DIFF_FORMAT_NO_HIGHLIGHT);
     }
 
     #[test]
     #[serial]
-    fn assert_that_sets_default_diff_format_env_var_set_to_unknown_mode() {
+    fn get_configured_diff_format_when_env_var_set_to_unknown_mode() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "not-valid");
 
-        let assertion = assert_that(42);
+        let diff_format = configured_diff_format();
 
-        assert_that(assertion.diff_format()).is_equal_to(&DEFAULT_DIFF_FORMAT);
+        assert_that(diff_format).is_equal_to(DEFAULT_DIFF_FORMAT);
     }
 
     #[test]
     #[serial]
-    fn assert_that_sets_default_diff_format_env_var_set_to_bold_mode() {
+    fn get_configured_diff_format_when_env_var_set_to_bold_mode() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "bold");
 
-        let assertion = assert_that(42);
+        let diff_format = configured_diff_format();
 
-        assert_that(assertion.diff_format()).is_equal_to(&DIFF_FORMAT_BOLD);
+        assert_that(diff_format).is_equal_to(DIFF_FORMAT_BOLD);
     }
 
     #[test]
     #[serial]
-    fn assert_that_sets_default_diff_format_env_var_set_to_bold_mode_no_color_env_var_set() {
+    fn get_configured_diff_format_when_env_var_set_to_bold_mode_and_no_color_env_var_set() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "bold");
         env::set_var("NO_COLOR", "1");
 
-        let assertion = assert_that(42);
+        let diff_format = configured_diff_format();
 
         env::remove_var("NO_COLOR");
 
-        assert_that(assertion.diff_format()).is_equal_to(&DIFF_FORMAT_BOLD);
+        assert_that(diff_format).is_equal_to(DIFF_FORMAT_BOLD);
     }
 
     #[test]
     #[serial]
-    fn assert_that_sets_default_diff_format_env_var_set_to_red_green_mode() {
+    fn get_configured_diff_format_when_env_var_set_to_red_green_mode() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "red-green");
 
-        let assertion = assert_that(42);
+        let diff_format = configured_diff_format();
 
-        assert_that(assertion.diff_format()).is_equal_to(&DIFF_FORMAT_RED_GREEN);
+        assert_that(diff_format).is_equal_to(DIFF_FORMAT_RED_GREEN);
     }
 
     #[test]
     #[serial]
-    fn assert_that_sets_default_diff_format_env_var_set_to_red_green_mode_no_color_env_var_set() {
+    fn get_configured_diff_format_when_env_var_set_to_red_green_mode_and_no_color_env_var_set() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "red-green");
         env::set_var("NO_COLOR", "1");
 
-        let assertion = assert_that(42);
+        let diff_format = configured_diff_format();
 
         env::remove_var("NO_COLOR");
 
-        assert_that(assertion.diff_format()).is_equal_to(&DIFF_FORMAT_NO_HIGHLIGHT);
+        assert_that(diff_format).is_equal_to(DIFF_FORMAT_NO_HIGHLIGHT);
     }
 
     #[test]
     #[serial]
-    fn assert_that_sets_default_diff_format_env_var_set_to_red_blue_mode() {
+    fn get_configured_diff_format_when_env_var_set_to_red_blue_mode() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "red-blue");
 
-        let assertion = assert_that(42);
+        let diff_format = configured_diff_format();
 
-        assert_that(assertion.diff_format()).is_equal_to(&DIFF_FORMAT_RED_BLUE);
+        assert_that(diff_format).is_equal_to(DIFF_FORMAT_RED_BLUE);
     }
 
     #[test]
     #[serial]
-    fn assert_that_sets_default_diff_format_env_var_set_to_red_blue_mode_no_color_env_var_set() {
+    fn get_configured_diff_format_when_env_var_set_to_red_blue_mode_and_no_color_env_var_set() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "red-blue");
         env::set_var("NO_COLOR", "1");
 
-        let assertion = assert_that(42);
+        let diff_format = configured_diff_format();
 
         env::remove_var("NO_COLOR");
 
-        assert_that(assertion.diff_format()).is_equal_to(&DIFF_FORMAT_NO_HIGHLIGHT);
+        assert_that(diff_format).is_equal_to(DIFF_FORMAT_NO_HIGHLIGHT);
     }
 
     #[test]
     #[serial]
-    fn assert_that_sets_default_diff_format_env_var_set_to_red_yellow_mode() {
+    fn get_configured_diff_format_when_env_var_set_to_red_yellow_mode() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "red-yellow");
 
-        let assertion = assert_that(42);
+        let diff_format = configured_diff_format();
 
-        assert_that(assertion.diff_format()).is_equal_to(&DIFF_FORMAT_RED_YELLOW);
+        assert_that(diff_format).is_equal_to(DIFF_FORMAT_RED_YELLOW);
     }
 
     #[test]
     #[serial]
-    fn assert_that_sets_default_diff_format_env_var_set_to_red_yellow_mode_no_color_env_var_set() {
+    fn get_configured_diff_format_when_env_var_set_to_red_yellow_mode_and_no_color_env_var_set() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "red-yellow");
         env::set_var("NO_COLOR", "1");
 
-        let assertion = assert_that(42);
+        let diff_format = configured_diff_format();
 
         env::remove_var("NO_COLOR");
 
-        assert_that(assertion.diff_format()).is_equal_to(&DIFF_FORMAT_NO_HIGHLIGHT);
+        assert_that(diff_format).is_equal_to(DIFF_FORMAT_NO_HIGHLIGHT);
     }
 
     #[test]
     #[serial]
-    fn assert_that_sets_default_diff_format_env_var_set_to_off() {
+    fn get_configured_diff_format_when_env_var_set_to_off() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "off");
 
-        let assertion = assert_that(42);
+        let diff_format = configured_diff_format();
 
-        assert_that(assertion.diff_format()).is_equal_to(&DIFF_FORMAT_NO_HIGHLIGHT);
+        assert_that(diff_format).is_equal_to(DIFF_FORMAT_NO_HIGHLIGHT);
     }
 
     proptest! {
@@ -237,9 +237,9 @@ mod with_colored_and_std_features {
         ) {
             env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, mode);
 
-            let assertion = assert_that(42);
+            let diff_format = configured_diff_format();
 
-            prop_assert_eq!(assertion.diff_format(), &DIFF_FORMAT_BOLD);
+            prop_assert_eq!(diff_format, DIFF_FORMAT_BOLD);
         }
 
         #[test]
@@ -249,9 +249,9 @@ mod with_colored_and_std_features {
         ) {
             env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, mode);
 
-            let assertion = assert_that(42);
+            let diff_format = configured_diff_format();
 
-            prop_assert_eq!(assertion.diff_format(), &DIFF_FORMAT_RED_BLUE);
+            prop_assert_eq!(diff_format, DIFF_FORMAT_RED_BLUE);
         }
 
         #[test]
@@ -261,9 +261,9 @@ mod with_colored_and_std_features {
         ) {
             env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, mode);
 
-            let assertion = assert_that(42);
+            let diff_format = configured_diff_format();
 
-            prop_assert_eq!(assertion.diff_format(), &DIFF_FORMAT_RED_YELLOW);
+            prop_assert_eq!(diff_format, DIFF_FORMAT_RED_YELLOW);
         }
 
         #[test]
@@ -273,9 +273,9 @@ mod with_colored_and_std_features {
         ) {
             env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, mode);
 
-            let assertion = assert_that(42);
+            let diff_format = configured_diff_format();
 
-            prop_assert_eq!(assertion.diff_format(), &DIFF_FORMAT_NO_HIGHLIGHT);
+            prop_assert_eq!(diff_format, DIFF_FORMAT_NO_HIGHLIGHT);
         }
     }
 

--- a/src/spec/mod.rs
+++ b/src/spec/mod.rs
@@ -245,10 +245,18 @@ pub fn assert_that<'a, S>(subject: S) -> Spec<'a, S, PanicOnFail> {
     {
         Spec::new(subject, PanicOnFail)
     }
-    #[cfg(feature = "colored")]
+    #[cfg(all(feature = "colored", not(feature = "std")))]
     {
         use crate::colored::configured_diff_format;
         Spec::new(subject, PanicOnFail).with_diff_format(configured_diff_format())
+    }
+    #[cfg(all(feature = "colored", feature = "std"))]
+    {
+        use crate::colored::configured_diff_format;
+        use crate::std::sync::OnceLock;
+        static DIFF_FORMAT: OnceLock<DiffFormat> = OnceLock::new();
+        let diff_format = DIFF_FORMAT.get_or_init(configured_diff_format);
+        Spec::new(subject, PanicOnFail).with_diff_format(diff_format.clone())
     }
 }
 


### PR DESCRIPTION
Currently the diff format configuration for colored assertion failures is read from the environment variables once for each test case. This is not necessary. Reading the configuration once per test run is sufficient.

Refactored the `assert_that` function to read the configuration for the colored mode only once per test run.