### PR TITLE
feat: implement soft assertions by providing new method `Spec::soft_panic()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,14 @@ Features of `asserting`:
 2. helpful error messages in case of failing assertions
 3. colored diffs between expected and actual values
 4. provide a reasonable number of assertions out of the box
-5. do not require that asserted types have to implement traits if it is not absolutely necessary
-6. support for asserting custom types with provided assertions
-7. writing custom assertions requires minimal effort
-8. support no-std environments
+5. soft assertions (execute multiple assertions before panicking) (see ["Soft assertions"])
+6. do not require that asserted types have to implement traits if it is not absolutely necessary
+7. support for asserting custom types with provided assertions
+8. writing custom assertions requires minimal effort
+9. support no-std environments
+
+For an overview of the provided features and many examples on how to use `asserting` see the
+[crate-level documentation][docs-url].
 
 ### Convenient to write
 
@@ -121,7 +125,7 @@ is set no colors are used regardless of the configured highlight mode.
 This chapter gives an overview for the assertions provided by `asserting`. For a comprehensive list
 of available assertions including examples browse the documentation of the [`assertions`] module.
 The documentation of the assertion traits contains examples on how to use each assertion. The
-[crate level documentation][docs-url] contains lots of examples as a quick introduction.
+[crate-level documentation][docs-url] contains lots of examples as a quick introduction.
 
 ### Equality
 
@@ -369,6 +373,8 @@ To start assertions on code use the `assert_that_code!()` macro.
 [code-coverage-url]: https://codecov.io/github/innoave/asserting
 
 <!-- External Links -->
+
+[soft assertions]: https://docs.rs/asserting/#soft-assertions
 
 [custom assertions]: https://docs.rs/asserting/#custom-assertions
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 //! * distinct and more helpful error messages for specific assertions
 //! * easy spotting the difference between the expected and the actual value
 //! * chaining of multiple assertions on the same subject
+//! * soft assertions
 //!
 //! An additional benefit of `asserting` is that it highlights differences
 //! between the expected value and the actual value for failed assertions.
@@ -117,6 +118,32 @@
 //!     .contains_all_of([1, 11, 13, 17, 19])
 //!     .contains_only([1, 3, 5, 7, 9, 11, 13, 17, 19, 23, 29, 31, 37, 43]);
 //! ```
+//!
+//! ## Soft assertions
+//!
+//! ```should_panic
+//! use asserting::prelude::*;
+//!
+//! verify_that!("the answer to all important questions is 42")
+//!     .contains("unimportant")
+//!     .has_at_most_length(41)
+//!     .soft_panic();
+//! ```
+//!
+//! executes both assertions and prints the messages of both failing
+//! assertions in the panic message:
+//!
+//! ```console
+//! assertion failed: expected subject to contain "unimportant"
+//!    but was: "the answer to all important questions is 42"
+//!   expected: "unimportant"
+//!
+//! assertion failed: expected subject has at most a length of 41
+//!    but was: 43
+//!   expected: <= 41
+//! ```
+//!
+//! For more details see [`Spec::soft_panic()`].
 //!
 //! ## Asserting custom types
 //!
@@ -556,6 +583,7 @@
 //! [`Spec`]: spec::Spec
 //! [`Spec::expecting()`]: spec::Spec::expecting
 //! [`Spec::satisfies()`]: spec::Spec::satisfies
+//! [`Spec::soft_panic()`]: spec::Spec::soft_panic
 //! [`assert_that`]: spec::assert_that
 //! [`assert_that_code`]: spec::assert_that_code
 //! [`verify_that`]: spec::verify_that

--- a/src/spec/tests.rs
+++ b/src/spec/tests.rs
@@ -163,9 +163,9 @@ fn verify_that_option_is_some_chained_with_has_value_fails_as_none() {
 
 #[test]
 fn verify_that_a_subject_with_custom_description_is_equal_to_fails() {
-    let an_anwser = 51;
+    let an_answer = 51;
 
-    let failures = verify_that(an_anwser)
+    let failures = verify_that(an_answer)
         .described_as("the answer to all important questions is 42")
         .is_equal_to(42)
         .display_failures();
@@ -202,4 +202,46 @@ expected answer is equal to 42
 "
         ]
     );
+}
+
+#[test]
+#[should_panic = "assertion failed: expected subject to contain \"unimportant\"\n   \
+       but was: \"the answer to all important questions is 42\"\n  \
+      expected: \"unimportant\"\n\
+    \n\
+    assertion failed: expected subject has at most a length of 41\n   \
+       but was: 43\n  \
+      expected: <= 41\n\
+"]
+fn soft_assertions_panic_once_with_multiple_failure_messages() {
+    let subject = "the answer to all important questions is 42";
+
+    verify_that(subject)
+        .contains("unimportant")
+        .has_at_most_length(41)
+        .soft_panic();
+}
+
+#[cfg(feature = "colored")]
+mod colored {
+    use crate::prelude::*;
+
+    #[test]
+    #[should_panic = "assertion failed: expected subject to contain \"unimportant\"\n   \
+       but was: \"\u{1b}[31mthe answer to all important questions is 42\u{1b}[0m\"\n  \
+      expected: \"\u{1b}[32munimportant\u{1b}[0m\"\n\
+    \n\
+    assertion failed: expected subject has at most a length of 41\n   \
+       but was: \u{1b}[31m43\u{1b}[0m\n  \
+      expected: <= \u{1b}[32m41\u{1b}[0m\n\
+"]
+    fn soft_assertions_panic_message_contains_highlighted_diffs() {
+        let subject = "the answer to all important questions is 42";
+
+        verify_that(subject)
+            .with_configured_diff_format()
+            .contains("unimportant")
+            .has_at_most_length(41)
+            .soft_panic();
+    }
 }

--- a/src/spec/tests.rs
+++ b/src/spec/tests.rs
@@ -205,6 +205,16 @@ expected answer is equal to 42
 }
 
 #[test]
+fn soft_assertions_with_chained_assertion_methods() {
+    let subject = "the answer to all important questions is 42".to_string();
+
+    verify_that(subject)
+        .contains("important")
+        .has_at_most_length(43)
+        .soft_panic();
+}
+
+#[test]
 #[should_panic = "assertion failed: expected subject to contain \"unimportant\"\n   \
        but was: \"the answer to all important questions is 42\"\n  \
       expected: \"unimportant\"\n\
@@ -214,7 +224,7 @@ expected answer is equal to 42
       expected: <= 41\n\
 "]
 fn soft_assertions_panic_once_with_multiple_failure_messages() {
-    let subject = "the answer to all important questions is 42";
+    let subject = "the answer to all important questions is 42".to_string();
 
     verify_that(subject)
         .contains("unimportant")


### PR DESCRIPTION
Soft assertions are a useful feature of assertion libs. `asserting` should support soft assertions as well.

Implemented the new method `Spec::soft_panic()` to provide soft assertions. Soft assertions are started with either the macro `verify_that!` or the function `verify_that()`. This constructs a `Spec` with the failing strategy `CollectFailures` which collects the failures of multiple assertions instead of panicking immediately at the first failing assertion. To finally panic if at least one assertion failed, the method `soft_panic()` must be called after the last assertion.