### PR TITLE
fix: `assert_that_code` does not highlight diffs in failures

### DIFF
--- a/src/colored/tests.rs
+++ b/src/colored/tests.rs
@@ -280,10 +280,38 @@ mod with_colored_and_std_features {
     }
 
     #[test]
+    #[serial]
+    fn assert_that_sets_the_diff_format_to_red_green() {
+        env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "red-green");
+
+        let assertion = assert_that(42);
+
+        assert_that(assertion.diff_format()).is_equal_to(&DIFF_FORMAT_RED_GREEN);
+    }
+
+    #[test]
+    #[serial]
     fn verify_that_sets_the_diff_format_to_no_highlighting() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "red-green");
 
         let assertion = verify_that(42);
+
+        assert_that(assertion.diff_format()).is_equal_to(&DIFF_FORMAT_NO_HIGHLIGHT);
+    }
+
+    #[test]
+    #[serial]
+    fn assert_that_code_sets_the_diff_format_to_red_green() {
+        env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "red-green");
+
+        let assertion = assert_that_code(|| {});
+
+        assert_that(assertion.diff_format()).is_equal_to(&DIFF_FORMAT_RED_GREEN);
+    }
+
+    #[test]
+    fn verify_that_code_sets_the_diff_format_to_no_highlighting() {
+        let assertion = verify_that_code(|| {});
 
         assert_that(assertion.diff_format()).is_equal_to(&DIFF_FORMAT_NO_HIGHLIGHT);
     }

--- a/src/spec/mod.rs
+++ b/src/spec/mod.rs
@@ -345,7 +345,16 @@ pub fn assert_that_code<'a, S>(code: S) -> Spec<'a, Code<S>, PanicOnFail>
 where
     S: FnOnce(),
 {
-    Spec::new(Code::from(code), PanicOnFail).named("the closure")
+    #[cfg(not(feature = "colored"))]
+    {
+        Spec::new(Code::from(code), PanicOnFail).named("the closure")
+    }
+    #[cfg(feature = "colored")]
+    {
+        Spec::new(Code::from(code), PanicOnFail)
+            .named("the closure")
+            .with_configured_diff_format()
+    }
 }
 
 /// Starts an assertion for some piece of code in the [`CollectFailures`] mode.


### PR DESCRIPTION
When asserting that code panics using the macro `assert_that_code!` or function `assert_that_code()` the differences in the panic message are not highlighted on failed assertion.

The function `assert_that_code` has been fixed to set the diff format according the configured mode.