### PR TITLE
feat: provide assertions for map-like types

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,23 @@ All the above assertions provided for any kind of iterator plus the following:
 | starts_with           | verify that an iterator/collection contains the given values as the first elements in order                                                      |
 | ends_with             | verify that an iterator/collection contains the given values as the last elements in order                                                       |
 
+### Maps
+
+For all types that implement the [`MapProperties`] trait. Currently, it is implemented for
+`std::collections::HashMap`, `std::collections::BTreeMap` and `hashbrown::HashMap`.
+
+| assertion               | description                                                                                                                      |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| contains_key            | verify that a map contains a mapping for the expected key                                                                        |
+| contains_keys           | verify that a map contains a mapping for each of the expected keys, ignoring order and duplicates                                |
+| contains_exactly_keys   | verify that a map contains exactly one mapping for each of the expected keys and no other mapping, ignoring order and duplicates |
+| does_not_contain_key    | verify that a map does not contain any mapping for the given key                                                                 |
+| does_not_contain_keys   | verify that a map does not contain any mapping for the given keys                                                                |
+| contains_value          | verify that a map contains at least one mapping where the value is equal to the expected one                                     |
+| contains_values         | verify that a map contains for each expected value at least one mapping where the value is equal, ignoring order and duplicates  |
+| does_not_contain_value  | verify that a map does not contain any mapping where the value is equal to the given one                                         |
+| does_not_contain_values | verify that a map does not contain any mapping where the value is equal to one of the given values                               |
+
 ### Panic
 
 for code inside a closure.
@@ -389,5 +406,7 @@ To start assertions on code use the `assert_that_code!()` macro.
 [`IsEmptyProperty`]: https://docs.rs/asserting/latest/asserting/properties/trait.IsEmptyProperty.html
 
 [`LengthProperty`]: https://docs.rs/asserting/latest/asserting/properties/trait.LengthProperty.html
+
+[`MapProperties`]: https://docs.rs/asserting/latest/asserting/properties/trait.MapProperties.html
 
 [`NO_COLOR`]: https://no-color.org/

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -1254,6 +1254,58 @@ pub trait AssertMapContainsKey<E> {
     /// ```
     #[track_caller]
     fn contains_keys(self, expected_keys: impl IntoIterator<Item = E>) -> Self;
+
+    /// Verify that the actual map does not contain any mapping for one of the
+    /// given keys.
+    ///
+    /// The order of the keys is not relevant and duplicates are ignored.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(not(feature = "std"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
+    /// use asserting::prelude::*;
+    /// use std::collections::HashMap;
+    ///
+    /// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).does_not_contain_keys([2, 3]);
+    /// assert_that!(&subject).does_not_contain_keys([6, 3, 7]);
+    /// assert_that!(&subject).does_not_contain_keys([3, 6, 3]);
+    /// # }
+    /// ```
+    ///
+    /// ```
+    /// use asserting::prelude::*;
+    /// use hashbrown::HashMap;
+    ///
+    /// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).does_not_contain_keys([6, 7]);
+    /// assert_that!(&subject).does_not_contain_keys([3, 2, 6]);
+    /// assert_that!(&subject).does_not_contain_keys([7, 2, 7]);
+    /// ```
+    ///
+    /// ```
+    /// # #[cfg(not(feature = "std"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
+    /// use asserting::prelude::*;
+    /// use std::collections::BTreeMap;
+    ///
+    /// let subject: BTreeMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).does_not_contain_keys([2, 3, 6, 7]);
+    /// assert_that!(&subject).does_not_contain_keys([7, 3, 6]);
+    /// assert_that!(&subject).does_not_contain_keys([2, 2, 9]);
+    /// # }
+    /// ```
+    #[track_caller]
+    fn does_not_contain_keys(self, expected_keys: impl IntoIterator<Item = E>) -> Self;
 }
 
 /// Assertions for the values of a map.
@@ -1448,4 +1500,56 @@ pub trait AssertMapContainsValue<E> {
     /// ```
     #[track_caller]
     fn contains_values(self, expected_values: impl IntoIterator<Item = E>) -> Self;
+
+    /// Verify that the actual map does not contain any mapping where the value
+    /// is one of the given values.
+    ///
+    /// The order of the values is not relevant and duplicates are ignored.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(not(feature = "std"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
+    /// use asserting::prelude::*;
+    /// use std::collections::HashMap;
+    ///
+    /// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).does_not_contain_values(["two", "three"]);
+    /// assert_that!(&subject).does_not_contain_values(["six", "three", "seven"]);
+    /// assert_that!(&subject).does_not_contain_values(["three", "six", "three"]);
+    /// # }
+    /// ```
+    ///
+    /// ```
+    /// use asserting::prelude::*;
+    /// use hashbrown::HashMap;
+    ///
+    /// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).does_not_contain_values(["six", "seven"]);
+    /// assert_that!(&subject).does_not_contain_values(["three", "two", "six"]);
+    /// assert_that!(&subject).does_not_contain_values(["seven", "two", "seven"]);
+    /// ```
+    ///
+    /// ```
+    /// # #[cfg(not(feature = "std"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
+    /// use asserting::prelude::*;
+    /// use std::collections::BTreeMap;
+    ///
+    /// let subject: BTreeMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).does_not_contain_values(["two", "three", "six", "seven"]);
+    /// assert_that!(&subject).does_not_contain_values(["seven", "three", "six"]);
+    /// assert_that!(&subject).does_not_contain_values(["two", "two", "nine"]);
+    /// # }
+    /// ```
+    #[track_caller]
+    fn does_not_contain_values(self, expected_values: impl IntoIterator<Item = E>) -> Self;
 }

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -1062,3 +1062,280 @@ pub trait AssertCodePanics {
     #[track_caller]
     fn panics_with_message(self, message: impl Into<String>) -> Self;
 }
+
+/// Assertions for the keys of a map.
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(not(feature = "std"))]
+/// # fn main() {}
+/// # #[cfg(feature = "std")]
+/// # fn main() {
+/// use asserting::prelude::*;
+/// use std::collections::HashMap;
+///
+/// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+///
+/// assert_that!(&subject).contains_key(5);
+/// assert_that!(subject).does_not_contain_key(3);
+/// # }
+/// ```
+///
+/// ```
+/// use asserting::prelude::*;
+/// use hashbrown::HashMap;
+///
+/// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+///
+/// assert_that!(&subject).contains_key(4);
+/// assert_that!(subject).does_not_contain_key(7);
+/// ```
+///
+/// ```
+/// # #[cfg(not(feature = "std"))]
+/// # fn main() {}
+/// # #[cfg(feature = "std")]
+/// # fn main() {
+/// use asserting::prelude::*;
+/// use std::collections::BTreeMap;
+///
+/// let subject: BTreeMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+///
+/// assert_that!(&subject).contains_key(4);
+/// assert_that!(subject).does_not_contain_key(2);
+/// # }
+/// ```
+pub trait AssertMapContainsKey<E> {
+    /// Verify that the actual map contains a mapping for the given key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(not(feature = "std"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
+    /// use asserting::prelude::*;
+    /// use std::collections::HashMap;
+    ///
+    /// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).contains_key(5);
+    /// assert_that!(subject).contains_key(1);
+    /// # }
+    /// ```
+    ///
+    /// ```
+    /// use asserting::prelude::*;
+    /// use hashbrown::HashMap;
+    ///
+    /// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).contains_key(4);
+    /// assert_that!(subject).contains_key(8);
+    /// ```
+    ///
+    /// ```
+    /// # #[cfg(not(feature = "std"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
+    /// use asserting::prelude::*;
+    /// use std::collections::BTreeMap;
+    ///
+    /// let subject: BTreeMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).contains_key(4);
+    /// assert_that!(subject).contains_key(5);
+    /// # }
+    /// ```
+    #[track_caller]
+    fn contains_key(self, expected_key: E) -> Self;
+
+    /// Verify that the actual map does not contain any mapping for the given
+    /// key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(not(feature = "std"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
+    /// use asserting::prelude::*;
+    /// use std::collections::HashMap;
+    ///
+    /// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).does_not_contain_key(2);
+    /// assert_that!(subject).does_not_contain_key(3);
+    /// # }
+    /// ```
+    ///
+    /// ```
+    /// use asserting::prelude::*;
+    /// use hashbrown::HashMap;
+    ///
+    /// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).does_not_contain_key(6);
+    /// assert_that!(subject).does_not_contain_key(7);
+    /// ```
+    ///
+    /// ```
+    /// # #[cfg(not(feature = "std"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
+    /// use asserting::prelude::*;
+    /// use std::collections::BTreeMap;
+    ///
+    /// let subject: BTreeMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).does_not_contain_key(3);
+    /// assert_that!(subject).does_not_contain_key(9);
+    /// # }
+    /// ```
+    #[track_caller]
+    fn does_not_contain_key(self, expected_key: E) -> Self;
+}
+
+/// Assertions for the values of a map.
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(not(feature = "std"))]
+/// # fn main() {}
+/// # #[cfg(feature = "std")]
+/// # fn main() {
+/// use asserting::prelude::*;
+/// use std::collections::HashMap;
+///
+/// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+///
+/// assert_that!(&subject).contains_value("five");
+/// assert_that!(subject).does_not_contain_value("three");
+/// # }
+/// ```
+///
+/// ```
+/// use asserting::prelude::*;
+/// use hashbrown::HashMap;
+///
+/// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+///
+/// assert_that!(&subject).contains_value("four");
+/// assert_that!(subject).does_not_contain_value("seven");
+/// ```
+///
+/// ```
+/// # #[cfg(not(feature = "std"))]
+/// # fn main() {}
+/// # #[cfg(feature = "std")]
+/// # fn main() {
+/// use asserting::prelude::*;
+/// use std::collections::BTreeMap;
+///
+/// let subject: BTreeMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+///
+/// assert_that!(&subject).contains_value("four");
+/// assert_that!(subject).does_not_contain_value("two");
+/// # }
+/// ```
+pub trait AssertMapContainsValue<E> {
+    /// Verify that the actual map contains at least one mapping where the value
+    /// is equal to the expected one.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(not(feature = "std"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
+    /// use asserting::prelude::*;
+    /// use std::collections::HashMap;
+    ///
+    /// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).contains_value("five");
+    /// assert_that!(subject).contains_value("one");
+    /// # }
+    /// ```
+    ///
+    /// ```
+    /// use asserting::prelude::*;
+    /// use hashbrown::HashMap;
+    ///
+    /// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).contains_value("one");
+    /// assert_that!(subject).contains_value("eight");
+    /// ```
+    ///
+    /// ```
+    /// # #[cfg(not(feature = "std"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
+    /// use asserting::prelude::*;
+    /// use std::collections::BTreeMap;
+    ///
+    /// let subject: BTreeMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).contains_value("four");
+    /// assert_that!(subject).contains_value("five");
+    /// # }
+    /// ```
+    #[track_caller]
+    fn contains_value(self, expected_value: E) -> Self;
+
+    /// Verify that the actual map does not contain any mapping where the value
+    /// is equal to the expected one.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(not(feature = "std"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
+    /// use asserting::prelude::*;
+    /// use std::collections::HashMap;
+    ///
+    /// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).does_not_contain_value("two");
+    /// assert_that!(subject).does_not_contain_value("three");
+    /// # }
+    /// ```
+    ///
+    /// ```
+    /// use asserting::prelude::*;
+    /// use hashbrown::HashMap;
+    ///
+    /// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).does_not_contain_value("six");
+    /// assert_that!(subject).does_not_contain_value("seven");
+    /// ```
+    ///
+    /// ```
+    /// # #[cfg(not(feature = "std"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
+    /// use asserting::prelude::*;
+    /// use std::collections::BTreeMap;
+    ///
+    /// let subject: BTreeMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).does_not_contain_value("three");
+    /// assert_that!(subject).does_not_contain_value("nine");
+    /// # }
+    /// ```
+    #[track_caller]
+    fn does_not_contain_value(self, expected_value: E) -> Self;
+}

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -1078,7 +1078,8 @@ pub trait AssertCodePanics {
 /// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
 ///
 /// assert_that!(&subject).contains_key(5);
-/// assert_that!(subject).does_not_contain_key(3);
+/// assert_that!(&subject).does_not_contain_key(3);
+/// assert_that!(&subject).contains_keys([4, 8]);
 /// # }
 /// ```
 ///
@@ -1089,7 +1090,8 @@ pub trait AssertCodePanics {
 /// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
 ///
 /// assert_that!(&subject).contains_key(4);
-/// assert_that!(subject).does_not_contain_key(7);
+/// assert_that!(&subject).does_not_contain_key(7);
+/// assert_that!(&subject).contains_keys([1, 5]);
 /// ```
 ///
 /// ```
@@ -1103,7 +1105,8 @@ pub trait AssertCodePanics {
 /// let subject: BTreeMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
 ///
 /// assert_that!(&subject).contains_key(4);
-/// assert_that!(subject).does_not_contain_key(2);
+/// assert_that!(&subject).does_not_contain_key(2);
+/// assert_that!(&subject).contains_keys([1, 4, 8]);
 /// # }
 /// ```
 pub trait AssertMapContainsKey<E> {
@@ -1199,6 +1202,58 @@ pub trait AssertMapContainsKey<E> {
     /// ```
     #[track_caller]
     fn does_not_contain_key(self, expected_key: E) -> Self;
+
+    /// Verify that the actual map contains a mapping for each of the given
+    /// keys.
+    ///
+    /// The order of the keys is not relevant and duplicates are ignored.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(not(feature = "std"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
+    /// use asserting::prelude::*;
+    /// use std::collections::HashMap;
+    ///
+    /// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).contains_keys([4, 5]);
+    /// assert_that!(&subject).contains_keys([8, 1, 5]);
+    /// assert_that!(&subject).contains_keys([8, 1, 1]);
+    /// # }
+    /// ```
+    ///
+    /// ```
+    /// use asserting::prelude::*;
+    /// use hashbrown::HashMap;
+    ///
+    /// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).contains_keys([1, 5]);
+    /// assert_that!(&subject).contains_keys([8, 1, 4]);
+    /// assert_that!(&subject).contains_keys([8, 4, 4]);
+    /// ```
+    ///
+    /// ```
+    /// # #[cfg(not(feature = "std"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
+    /// use asserting::prelude::*;
+    /// use std::collections::BTreeMap;
+    ///
+    /// let subject: BTreeMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).contains_keys([1, 4, 5, 8]);
+    /// assert_that!(&subject).contains_keys([5, 4, 8]);
+    /// assert_that!(&subject).contains_keys([5, 5, 8]);
+    /// # }
+    /// ```
+    #[track_caller]
+    fn contains_keys(self, expected_keys: impl IntoIterator<Item = E>) -> Self;
 }
 
 /// Assertions for the values of a map.
@@ -1216,7 +1271,8 @@ pub trait AssertMapContainsKey<E> {
 /// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
 ///
 /// assert_that!(&subject).contains_value("five");
-/// assert_that!(subject).does_not_contain_value("three");
+/// assert_that!(&subject).does_not_contain_value("three");
+/// assert_that!(&subject).contains_values(["four", "eight"]);
 /// # }
 /// ```
 ///
@@ -1227,7 +1283,8 @@ pub trait AssertMapContainsKey<E> {
 /// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
 ///
 /// assert_that!(&subject).contains_value("four");
-/// assert_that!(subject).does_not_contain_value("seven");
+/// assert_that!(&subject).does_not_contain_value("seven");
+/// assert_that!(&subject).contains_values(["one", "five"]);
 /// ```
 ///
 /// ```
@@ -1241,7 +1298,8 @@ pub trait AssertMapContainsKey<E> {
 /// let subject: BTreeMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
 ///
 /// assert_that!(&subject).contains_value("four");
-/// assert_that!(subject).does_not_contain_value("two");
+/// assert_that!(&subject).does_not_contain_value("two");
+/// assert_that!(&subject).contains_values(["four", "one", "eight"]);
 /// # }
 /// ```
 pub trait AssertMapContainsValue<E> {
@@ -1338,4 +1396,56 @@ pub trait AssertMapContainsValue<E> {
     /// ```
     #[track_caller]
     fn does_not_contain_value(self, expected_value: E) -> Self;
+
+    /// Verify that the actual map contains at least one mapping for each of the
+    /// given values, where the mapping contains one of the expected values.
+    ///
+    /// The order of the values is not relevant and duplicates are ignored.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(not(feature = "std"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
+    /// use asserting::prelude::*;
+    /// use std::collections::HashMap;
+    ///
+    /// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).contains_values(["four", "five"]);
+    /// assert_that!(&subject).contains_values(["eight", "one", "five"]);
+    /// assert_that!(&subject).contains_values(["eight", "one", "one"]);
+    /// # }
+    /// ```
+    ///
+    /// ```
+    /// use asserting::prelude::*;
+    /// use hashbrown::HashMap;
+    ///
+    /// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).contains_values(["one", "five"]);
+    /// assert_that!(&subject).contains_values(["eight", "one", "four"]);
+    /// assert_that!(&subject).contains_values(["eight", "four", "four"]);
+    /// ```
+    ///
+    /// ```
+    /// # #[cfg(not(feature = "std"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
+    /// use asserting::prelude::*;
+    /// use std::collections::BTreeMap;
+    ///
+    /// let subject: BTreeMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).contains_values(["one", "four", "five", "eight"]);
+    /// assert_that!(&subject).contains_values(["five", "four", "eight"]);
+    /// assert_that!(&subject).contains_values(["five", "five", "eight"]);
+    /// # }
+    /// ```
+    #[track_caller]
+    fn contains_values(self, expected_values: impl IntoIterator<Item = E>) -> Self;
 }

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -1080,6 +1080,8 @@ pub trait AssertCodePanics {
 /// assert_that!(&subject).contains_key(5);
 /// assert_that!(&subject).does_not_contain_key(3);
 /// assert_that!(&subject).contains_keys([4, 8]);
+/// assert_that!(&subject).does_not_contain_keys([3, 2, 7]);
+/// assert_that!(&subject).contains_exactly_keys([4, 1, 5, 8]);
 /// # }
 /// ```
 ///
@@ -1092,6 +1094,8 @@ pub trait AssertCodePanics {
 /// assert_that!(&subject).contains_key(4);
 /// assert_that!(&subject).does_not_contain_key(7);
 /// assert_that!(&subject).contains_keys([1, 5]);
+/// assert_that!(&subject).does_not_contain_keys([2, 7, 6]);
+/// assert_that!(&subject).contains_exactly_keys([1, 4, 5, 8]);
 /// ```
 ///
 /// ```
@@ -1107,6 +1111,8 @@ pub trait AssertCodePanics {
 /// assert_that!(&subject).contains_key(4);
 /// assert_that!(&subject).does_not_contain_key(2);
 /// assert_that!(&subject).contains_keys([1, 4, 8]);
+/// assert_that!(&subject).does_not_contain_keys([2, 3, 6]);
+/// assert_that!(&subject).contains_exactly_keys([4, 5, 8, 1]);
 /// # }
 /// ```
 pub trait AssertMapContainsKey<E> {
@@ -1306,6 +1312,58 @@ pub trait AssertMapContainsKey<E> {
     /// ```
     #[track_caller]
     fn does_not_contain_keys(self, expected_keys: impl IntoIterator<Item = E>) -> Self;
+
+    /// Verifies that the actual map contains a mapping for each of the expected
+    /// keys but no more.
+    ///
+    /// The order of the keys is not relevant and duplicates are ignored.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(not(feature = "std"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
+    /// use asserting::prelude::*;
+    /// use std::collections::HashMap;
+    ///
+    /// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).contains_exactly_keys([4, 1, 5, 8]);
+    /// assert_that!(&subject).contains_exactly_keys([1, 4, 5, 8]);
+    /// assert_that!(&subject).contains_exactly_keys([1, 4, 5, 8, 8]);
+    /// # }
+    /// ```
+    ///
+    /// ```
+    /// use asserting::prelude::*;
+    /// use hashbrown::HashMap;
+    ///
+    /// let subject: HashMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).contains_exactly_keys([4, 1, 5, 8]);
+    /// assert_that!(&subject).contains_exactly_keys([1, 4, 5, 8]);
+    /// assert_that!(&subject).contains_exactly_keys([1, 1, 4, 5, 8]);
+    /// ```
+    ///
+    /// ```
+    /// # #[cfg(not(feature = "std"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "std")]
+    /// # fn main() {
+    /// use asserting::prelude::*;
+    /// use std::collections::BTreeMap;
+    ///
+    /// let subject: BTreeMap<_, _> = [(4, "four"), (1, "one"), (5, "five"), (8, "eight")].into();
+    ///
+    /// assert_that!(&subject).contains_exactly_keys([1, 4, 5, 8]);
+    /// assert_that!(&subject).contains_exactly_keys([5, 4, 1, 8]);
+    /// assert_that!(&subject).contains_exactly_keys([5, 4, 4, 1, 8]);
+    /// # }
+    /// ```
+    #[track_caller]
+    fn contains_exactly_keys(self, expected_keys: impl IntoIterator<Item = E>) -> Self;
 }
 
 /// Assertions for the values of a map.
@@ -1325,6 +1383,7 @@ pub trait AssertMapContainsKey<E> {
 /// assert_that!(&subject).contains_value("five");
 /// assert_that!(&subject).does_not_contain_value("three");
 /// assert_that!(&subject).contains_values(["four", "eight"]);
+/// assert_that!(&subject).does_not_contain_values(["three", "two", "seven"]);
 /// # }
 /// ```
 ///
@@ -1337,6 +1396,7 @@ pub trait AssertMapContainsKey<E> {
 /// assert_that!(&subject).contains_value("four");
 /// assert_that!(&subject).does_not_contain_value("seven");
 /// assert_that!(&subject).contains_values(["one", "five"]);
+/// assert_that!(&subject).does_not_contain_values(["two", "seven", "six"]);
 /// ```
 ///
 /// ```
@@ -1352,6 +1412,7 @@ pub trait AssertMapContainsKey<E> {
 /// assert_that!(&subject).contains_value("four");
 /// assert_that!(&subject).does_not_contain_value("two");
 /// assert_that!(&subject).contains_values(["four", "one", "eight"]);
+/// assert_that!(&subject).does_not_contain_values(["two", "three", "six"]);
 /// # }
 /// ```
 pub trait AssertMapContainsValue<E> {

--- a/src/expectations.rs
+++ b/src/expectations.rs
@@ -3,34 +3,9 @@
 #![allow(missing_docs)]
 #![warn(clippy::return_self_not_must_use)]
 
-use crate::spec::{DiffFormat, Expectation, Expression};
 use crate::std::marker::PhantomData;
 use crate::std::{string::String, vec::Vec};
 use hashbrown::HashSet;
-
-pub struct Not<E>(pub E);
-
-impl<E, S> Expectation<S> for Not<E>
-where
-    E: Negatable<S> + Expectation<S>,
-{
-    fn test(&mut self, subject: &S) -> bool {
-        !self.0.test(subject)
-    }
-
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
-        self.0.negated_message(expression, actual, format)
-    }
-}
-
-pub trait Negatable<S> {
-    fn negated_message(
-        &self,
-        expression: Expression<'_>,
-        actual: &S,
-        format: &DiffFormat,
-    ) -> String;
-}
 
 #[must_use]
 pub struct Predicate<F> {
@@ -517,21 +492,46 @@ pub struct MapContainsKey<E> {
 }
 
 #[must_use]
+pub struct MapDoesNotContainKey<E> {
+    pub expected_key: E,
+}
+
+#[must_use]
 pub struct MapContainsValue<E> {
+    pub expected_value: E,
+}
+
+#[must_use]
+pub struct MapDoesNotContainValue<E> {
     pub expected_value: E,
 }
 
 #[must_use]
 pub struct MapContainsKeys<E> {
     pub expected_keys: Vec<E>,
-    pub missing_keys: HashSet<usize>,
+    pub missing: HashSet<usize>,
 }
 
 impl<E> MapContainsKeys<E> {
     pub fn new(expected_keys: impl IntoIterator<Item = E>) -> Self {
         Self {
             expected_keys: Vec::from_iter(expected_keys),
-            missing_keys: HashSet::new(),
+            missing: HashSet::new(),
+        }
+    }
+}
+
+#[must_use]
+pub struct MapDoesNotContainKeys<E> {
+    pub expected_keys: Vec<E>,
+    pub extra: HashSet<usize>,
+}
+
+impl<E> MapDoesNotContainKeys<E> {
+    pub fn new(expected_keys: impl IntoIterator<Item = E>) -> Self {
+        Self {
+            expected_keys: Vec::from_iter(expected_keys),
+            extra: HashSet::new(),
         }
     }
 }
@@ -539,14 +539,29 @@ impl<E> MapContainsKeys<E> {
 #[must_use]
 pub struct MapContainsValues<E> {
     pub expected_values: Vec<E>,
-    pub missing_values: HashSet<usize>,
+    pub missing: HashSet<usize>,
 }
 
 impl<E> MapContainsValues<E> {
     pub fn new(expected_values: impl IntoIterator<Item = E>) -> Self {
         Self {
             expected_values: Vec::from_iter(expected_values),
-            missing_values: HashSet::new(),
+            missing: HashSet::new(),
+        }
+    }
+}
+
+#[must_use]
+pub struct MapDoesNotContainValues<E> {
+    pub expected_values: Vec<E>,
+    pub extra: HashSet<usize>,
+}
+
+impl<E> MapDoesNotContainValues<E> {
+    pub fn new(expected_values: impl IntoIterator<Item = E>) -> Self {
+        Self {
+            expected_values: Vec::from_iter(expected_values),
+            extra: HashSet::new(),
         }
     }
 }

--- a/src/expectations.rs
+++ b/src/expectations.rs
@@ -566,6 +566,23 @@ impl<E> MapDoesNotContainValues<E> {
     }
 }
 
+#[must_use]
+pub struct MapContainsExactlyKeys<E> {
+    pub expected_keys: Vec<E>,
+    pub missing: HashSet<usize>,
+    pub extra: HashSet<usize>,
+}
+
+impl<E> MapContainsExactlyKeys<E> {
+    pub fn new(expected_keys: impl IntoIterator<Item = E>) -> Self {
+        Self {
+            expected_keys: Vec::from_iter(expected_keys),
+            missing: HashSet::new(),
+            extra: HashSet::new(),
+        }
+    }
+}
+
 #[cfg(feature = "panic")]
 #[cfg_attr(docsrs, doc(cfg(feature = "panic")))]
 pub use panic::{DoesNotPanic, DoesPanic};

--- a/src/expectations.rs
+++ b/src/expectations.rs
@@ -480,12 +480,47 @@ impl<E> IterEndsWith<E> {
     }
 }
 
+pub struct Not<E>(pub E);
+
+impl<E, S> Expectation<S> for Not<E>
+where
+    E: Negatable<S> + Expectation<S>,
+{
+    fn test(&mut self, subject: &S) -> bool {
+        !self.0.test(subject)
+    }
+
+    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+        self.0.negated_message(expression, actual, format)
+    }
+}
+
+pub trait Negatable<S> {
+    fn negated_message(
+        &self,
+        expression: Expression<'_>,
+        actual: &S,
+        format: &DiffFormat,
+    ) -> String;
+}
+
+#[must_use]
+pub struct MapContainsKey<E> {
+    pub expected_key: E,
+}
+
+#[must_use]
+pub struct MapContainsValue<E> {
+    pub expected_value: E,
+}
+
 #[must_use]
 pub struct Predicate<F> {
     pub predicate: F,
     pub message: Option<String>,
 }
 
+use crate::spec::{DiffFormat, Expectation, Expression};
 #[cfg(feature = "panic")]
 #[cfg_attr(docsrs, doc(cfg(feature = "panic")))]
 pub use panic::{DoesNotPanic, DoesPanic};

--- a/src/iterator/mod.rs
+++ b/src/iterator/mod.rs
@@ -113,8 +113,8 @@ where
     }
 
     fn message(&self, expression: Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
-        let missing = collect_values(&self.missing, &self.expected);
-        let extra = collect_values(&self.extra, actual);
+        let missing = collect_selected_values(&self.missing, &self.expected);
+        let extra = collect_selected_values(&self.extra, actual);
         let marked_actual =
             mark_selected_items_in_collection(actual, &self.extra, format, mark_unexpected);
         let marked_expected =
@@ -185,7 +185,7 @@ where
             mark_selected_items_in_collection(actual, &extra, format, mark_unexpected);
         let marked_expected =
             mark_selected_items_in_collection(&self.expected, &self.missing, format, mark_missing);
-        let missing = collect_values(&self.missing, &self.expected);
+        let missing = collect_selected_values(&self.missing, &self.expected);
 
         format!(
             r"expected {expression} contains all of {:?}
@@ -225,7 +225,7 @@ where
             mark_selected_items_in_collection(actual, &self.extra, format, mark_unexpected);
         let marked_expected =
             mark_selected_items_in_collection(&self.expected, &missing, format, mark_missing);
-        let extra = collect_values(&self.extra, actual);
+        let extra = collect_selected_values(&self.extra, actual);
 
         format!(
             r"expected {expression} contains only {:?}
@@ -267,7 +267,7 @@ where
             format,
             mark_unexpected,
         );
-        let duplicates = collect_values(&self.duplicates, actual);
+        let duplicates = collect_selected_values(&self.duplicates, actual);
         let mut expected_duplicates_and_missing = HashSet::new();
         for (expected_index, expected) in self.expected.iter().enumerate() {
             if duplicates.iter().any(|duplicate| *duplicate == expected)
@@ -282,7 +282,7 @@ where
             format,
             mark_missing,
         );
-        let extra = collect_values(&self.extra, actual);
+        let extra = collect_selected_values(&self.extra, actual);
 
         format!(
             r"expected {expression} contains only once {:?}
@@ -379,7 +379,7 @@ where
     }
 
     fn message(&self, expression: Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
-        let out_of_order = collect_values(&self.out_of_order, actual);
+        let out_of_order = collect_selected_values(&self.out_of_order, actual);
         let mut expected_indices = self.missing.clone();
         for (expected_index, expected) in self.expected.iter().enumerate() {
             if out_of_order.iter().any(|actual| *actual == expected) {
@@ -396,8 +396,8 @@ where
         let marked_actual =
             mark_selected_items_in_collection(actual, &actual_indices, format, mark_unexpected);
 
-        let missing = collect_values(&self.missing, &self.expected);
-        let extra = collect_values(&self.extra, actual);
+        let missing = collect_selected_values(&self.missing, &self.expected);
+        let extra = collect_selected_values(&self.extra, actual);
 
         format!(
             r"expected {expression} contains exactly in order {:?}
@@ -482,8 +482,8 @@ where
             mark_selected_items_in_collection(actual, &self.extra, format, mark_unexpected);
         let marked_expected =
             mark_selected_items_in_collection(&self.expected, &self.missing, format, mark_missing);
-        let missing = collect_values(&self.missing, &self.expected);
-        let extra = collect_values(&self.extra, actual);
+        let missing = collect_selected_values(&self.missing, &self.expected);
+        let extra = collect_selected_values(&self.extra, actual);
 
         format!(
             r"expected {expression} contains sequence {:?}
@@ -522,7 +522,7 @@ where
     fn message(&self, expression: Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
         let marked_expected =
             mark_selected_items_in_collection(&self.expected, &self.missing, format, mark_missing);
-        let missing = collect_values(&self.missing, &self.expected);
+        let missing = collect_selected_values(&self.missing, &self.expected);
 
         format!(
             r"expected {expression} contains all of {:?} in order
@@ -567,8 +567,8 @@ where
             mark_selected_items_in_collection(actual, &self.extra, format, mark_unexpected);
         let marked_expected =
             mark_selected_items_in_collection(&self.expected, &self.missing, format, mark_missing);
-        let missing = collect_values(&self.missing, &self.expected);
-        let extra = collect_values(&self.extra, actual);
+        let missing = collect_selected_values(&self.missing, &self.expected);
+        let extra = collect_selected_values(&self.extra, actual);
 
         format!(
             r"expected {expression} starts with {:?}
@@ -614,8 +614,8 @@ where
             mark_selected_items_in_collection(actual, &self.extra, format, mark_unexpected);
         let marked_expected =
             mark_selected_items_in_collection(&self.expected, &self.missing, format, mark_missing);
-        let missing = collect_values(&self.missing, &self.expected);
-        let extra = collect_values(&self.extra, actual);
+        let missing = collect_selected_values(&self.missing, &self.expected);
+        let extra = collect_selected_values(&self.extra, actual);
 
         format!(
             r"expected {expression} ends with {:?}
@@ -628,7 +628,7 @@ where
     }
 }
 
-fn collect_values<'a, T>(indices: &HashSet<usize>, collection: &'a [T]) -> Vec<&'a T> {
+pub fn collect_selected_values<'a, T>(indices: &HashSet<usize>, collection: &'a [T]) -> Vec<&'a T> {
     collection
         .iter()
         .enumerate()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -658,6 +658,7 @@ mod float;
 mod integer;
 mod iterator;
 mod length;
+mod map;
 mod number;
 mod option;
 mod order;

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -1,16 +1,25 @@
 use crate::assertions::{AssertMapContainsKey, AssertMapContainsValue};
-use crate::colored::{mark_missing, mark_unexpected};
-use crate::expectations::{MapContainsKey, MapContainsValue, Negatable, Not};
-use crate::properties::{KeysProperty, ValuesProperty};
+use crate::colored::{
+    mark_all_entries_in_map, mark_missing, mark_selected_entries_in_map,
+    mark_selected_items_in_collection, mark_unexpected_substr,
+};
+use crate::expectations::{
+    MapContainsKey, MapContainsKeys, MapContainsValue, MapContainsValues, Negatable, Not,
+};
+use crate::iterator::collect_selected_values;
+use crate::properties::MapProperties;
 use crate::spec::{DiffFormat, Expectation, Expression, FailingStrategy, Spec};
 use crate::std::fmt::Debug;
 use crate::std::format;
 use crate::std::string::String;
+use crate::std::vec::Vec;
+use hashbrown::HashSet;
 
 impl<S, E, R> AssertMapContainsKey<E> for Spec<'_, S, R>
 where
-    S: KeysProperty + Debug,
-    <S as KeysProperty>::Key: PartialEq<E>,
+    S: MapProperties + Debug,
+    <S as MapProperties>::Key: PartialEq<E> + Debug,
+    <S as MapProperties>::Value: Debug,
     E: Debug,
     R: FailingStrategy,
 {
@@ -21,12 +30,17 @@ where
     fn does_not_contain_key(self, expected_key: E) -> Self {
         self.expecting(Not(MapContainsKey { expected_key }))
     }
+
+    fn contains_keys(self, expected_keys: impl IntoIterator<Item = E>) -> Self {
+        self.expecting(MapContainsKeys::new(expected_keys))
+    }
 }
 
 impl<M, E> Expectation<M> for MapContainsKey<E>
 where
-    M: KeysProperty + Debug,
-    <M as KeysProperty>::Key: PartialEq<E>,
+    M: MapProperties,
+    <M as MapProperties>::Key: PartialEq<E> + Debug,
+    <M as MapProperties>::Value: Debug,
     E: Debug,
 {
     fn test(&mut self, subject: &M) -> bool {
@@ -35,36 +49,109 @@ where
 
     fn message(&self, expression: Expression<'_>, actual: &M, format: &DiffFormat) -> String {
         let expected_key = &self.expected_key;
-        let marked_actual = mark_unexpected(actual, format);
+        let actual_entries: Vec<_> = actual.entries_property().collect();
+        let marked_actual =
+            mark_all_entries_in_map(&actual_entries, format, mark_unexpected_substr);
         let marked_expected = mark_missing(&self.expected_key, format);
 
         format!("expected {expression} contains key {expected_key:?}\n   but was: {marked_actual}\n  expected: {marked_expected}")
     }
 }
 
-impl<S, E> Negatable<S> for MapContainsKey<E>
+impl<M, E> Negatable<M> for MapContainsKey<E>
 where
-    S: Debug,
+    M: MapProperties,
+    <M as MapProperties>::Key: PartialEq<E> + Debug,
+    <M as MapProperties>::Value: Debug,
     E: Debug,
 {
     fn negated_message(
         &self,
         expression: Expression<'_>,
-        actual: &S,
+        actual: &M,
         format: &DiffFormat,
     ) -> String {
         let expected_key = &self.expected_key;
-        let marked_actual = mark_unexpected(actual, format);
+        let actual_entries: Vec<_> = actual.entries_property().collect();
+        let found_keys: HashSet<usize> = actual_entries
+            .iter()
+            .enumerate()
+            .filter_map(|(index, (k, _))| {
+                if *k == &self.expected_key {
+                    Some(index)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let marked_actual = mark_selected_entries_in_map(
+            &actual_entries,
+            &found_keys,
+            format,
+            mark_unexpected_substr,
+        );
         let marked_expected = mark_missing(&self.expected_key, format);
 
         format!("expected {expression} does not contain key {expected_key:?}\n   but was: {marked_actual}\n  expected: {marked_expected}")
     }
 }
 
+impl<M, E> Expectation<M> for MapContainsKeys<E>
+where
+    M: MapProperties,
+    <M as MapProperties>::Key: PartialEq<E> + Debug,
+    <M as MapProperties>::Value: Debug,
+    E: Debug,
+{
+    fn test(&mut self, subject: &M) -> bool {
+        let keys = subject.keys_property().collect::<Vec<_>>();
+        let missing_keys = &mut self.missing_keys;
+        for (expected_index, expected_key) in self.expected_keys.iter().enumerate() {
+            if !keys.iter().any(|k| *k == expected_key) {
+                missing_keys.insert(expected_index);
+            }
+        }
+        missing_keys.is_empty()
+    }
+
+    fn message(&self, expression: Expression<'_>, actual: &M, format: &DiffFormat) -> String {
+        let expected_keys = &self.expected_keys;
+        let missing = &self.missing_keys;
+        let actual_entries: Vec<_> = actual.entries_property().collect();
+        let mut extra_entries = HashSet::new();
+        for (actual_index, actual_entry) in actual_entries.iter().enumerate() {
+            if !expected_keys
+                .iter()
+                .any(|expected| actual_entry.0 == expected)
+            {
+                extra_entries.insert(actual_index);
+            }
+        }
+        let marked_actual = mark_selected_entries_in_map(
+            &actual_entries,
+            &extra_entries,
+            format,
+            mark_unexpected_substr,
+        );
+        let marked_expected =
+            mark_selected_items_in_collection(expected_keys, missing, format, mark_missing);
+        let missing_keys = collect_selected_values(&self.missing_keys, expected_keys);
+
+        format!(
+            r"expected {expression} contains keys {expected_keys:?}
+   but was: {marked_actual}
+  expected: {marked_expected}
+   missing: {missing_keys:?}"
+        )
+    }
+}
+
 impl<S, E, R> AssertMapContainsValue<E> for Spec<'_, S, R>
 where
-    S: ValuesProperty + Debug,
-    <S as ValuesProperty>::Value: PartialEq<E>,
+    S: MapProperties,
+    <S as MapProperties>::Key: Debug,
+    <S as MapProperties>::Value: PartialEq<E> + Debug,
     E: Debug,
     R: FailingStrategy,
 {
@@ -75,12 +162,17 @@ where
     fn does_not_contain_value(self, expected_value: E) -> Self {
         self.expecting(Not(MapContainsValue { expected_value }))
     }
+
+    fn contains_values(self, expected_values: impl IntoIterator<Item = E>) -> Self {
+        self.expecting(MapContainsValues::new(expected_values))
+    }
 }
 
 impl<M, E> Expectation<M> for MapContainsValue<E>
 where
-    M: ValuesProperty + Debug,
-    <M as ValuesProperty>::Value: PartialEq<E>,
+    M: MapProperties,
+    <M as MapProperties>::Key: Debug,
+    <M as MapProperties>::Value: PartialEq<E> + Debug,
     E: Debug,
 {
     fn test(&mut self, subject: &M) -> bool {
@@ -89,191 +181,272 @@ where
 
     fn message(&self, expression: Expression<'_>, actual: &M, format: &DiffFormat) -> String {
         let expected_value = &self.expected_value;
-        let marked_actual = mark_unexpected(actual, format);
+        let actual_entries: Vec<_> = actual.entries_property().collect();
+        let marked_actual =
+            mark_all_entries_in_map(&actual_entries, format, mark_unexpected_substr);
         let marked_expected = mark_missing(&self.expected_value, format);
 
         format!("expected {expression} contains value {expected_value:?}\n   but was: {marked_actual}\n  expected: {marked_expected}")
     }
 }
 
-impl<S, E> Negatable<S> for MapContainsValue<E>
+impl<M, E> Negatable<M> for MapContainsValue<E>
 where
-    S: Debug,
+    M: MapProperties,
+    <M as MapProperties>::Key: Debug,
+    <M as MapProperties>::Value: PartialEq<E> + Debug,
     E: Debug,
 {
     fn negated_message(
         &self,
         expression: Expression<'_>,
-        actual: &S,
+        actual: &M,
         format: &DiffFormat,
     ) -> String {
         let expected_value = &self.expected_value;
-        let marked_actual = mark_unexpected(actual, format);
+        let actual_entries: Vec<_> = actual.entries_property().collect();
+        let found_keys: HashSet<usize> = actual_entries
+            .iter()
+            .enumerate()
+            .filter_map(|(index, (_, v))| {
+                if *v == &self.expected_value {
+                    Some(index)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let marked_actual = mark_selected_entries_in_map(
+            &actual_entries,
+            &found_keys,
+            format,
+            mark_unexpected_substr,
+        );
         let marked_expected = mark_missing(&self.expected_value, format);
 
         format!("expected {expression} does not contain value {expected_value:?}\n   but was: {marked_actual}\n  expected: {marked_expected}")
     }
 }
 
+impl<M, E> Expectation<M> for MapContainsValues<E>
+where
+    M: MapProperties,
+    <M as MapProperties>::Key: Debug,
+    <M as MapProperties>::Value: PartialEq<E> + Debug,
+    E: Debug,
+{
+    fn test(&mut self, subject: &M) -> bool {
+        let values = subject.values_property().collect::<Vec<_>>();
+        let missing_values = &mut self.missing_values;
+        for (expected_index, expected_value) in self.expected_values.iter().enumerate() {
+            if !values.iter().any(|v| *v == expected_value) {
+                missing_values.insert(expected_index);
+            }
+        }
+        missing_values.is_empty()
+    }
+
+    fn message(&self, expression: Expression<'_>, actual: &M, format: &DiffFormat) -> String {
+        let expected_values = &self.expected_values;
+        let missing = &self.missing_values;
+        let actual_entries: Vec<_> = actual.entries_property().collect();
+        let mut extra_entries = HashSet::new();
+        for (actual_index, actual_entry) in actual_entries.iter().enumerate() {
+            if !expected_values
+                .iter()
+                .any(|expected| actual_entry.1 == expected)
+            {
+                extra_entries.insert(actual_index);
+            }
+        }
+        let marked_actual = mark_selected_entries_in_map(
+            &actual_entries,
+            &extra_entries,
+            format,
+            mark_unexpected_substr,
+        );
+        let marked_expected =
+            mark_selected_items_in_collection(expected_values, missing, format, mark_missing);
+        let missing_values = collect_selected_values(&self.missing_values, expected_values);
+
+        format!(
+            r"expected {expression} contains values {expected_values:?}
+   but was: {marked_actual}
+  expected: {marked_expected}
+   missing: {missing_values:?}"
+        )
+    }
+}
+
 mod hashbrown_impls {
-    use crate::properties::{KeysProperty, ValuesProperty};
+    use crate::properties::MapProperties;
     use crate::std::iter::Iterator;
     use hashbrown::HashMap;
 
-    impl<K, V, H> KeysProperty for HashMap<K, V, H> {
+    impl<K, V, H> MapProperties for HashMap<K, V, H> {
         type Key = K;
-
-        fn keys_property(&self) -> impl Iterator<Item = &<Self as KeysProperty>::Key> {
-            self.keys()
-        }
-    }
-
-    impl<K, V, H> KeysProperty for &HashMap<K, V, H> {
-        type Key = K;
-
-        fn keys_property(&self) -> impl Iterator<Item = &Self::Key> {
-            self.keys()
-        }
-    }
-
-    impl<K, V, H> KeysProperty for &mut HashMap<K, V, H> {
-        type Key = K;
-
-        fn keys_property(&self) -> impl Iterator<Item = &Self::Key> {
-            self.keys()
-        }
-    }
-
-    impl<K, V, H> ValuesProperty for HashMap<K, V, H> {
         type Value = V;
+
+        fn keys_property(&self) -> impl Iterator<Item = &<Self as MapProperties>::Key> {
+            self.keys()
+        }
 
         fn values_property(&self) -> impl Iterator<Item = &Self::Value> {
             self.values()
         }
+
+        fn entries_property(&self) -> impl Iterator<Item = (&Self::Key, &Self::Value)> {
+            self.iter()
+        }
     }
 
-    impl<K, V, H> ValuesProperty for &HashMap<K, V, H> {
+    impl<K, V, H> MapProperties for &HashMap<K, V, H> {
+        type Key = K;
         type Value = V;
+
+        fn keys_property(&self) -> impl Iterator<Item = &<Self as MapProperties>::Key> {
+            self.keys()
+        }
 
         fn values_property(&self) -> impl Iterator<Item = &Self::Value> {
             self.values()
         }
+
+        fn entries_property(&self) -> impl Iterator<Item = (&Self::Key, &Self::Value)> {
+            self.iter()
+        }
     }
 
-    impl<K, V, H> ValuesProperty for &mut HashMap<K, V, H> {
+    impl<K, V, H> MapProperties for &mut HashMap<K, V, H> {
+        type Key = K;
         type Value = V;
+
+        fn keys_property(&self) -> impl Iterator<Item = &<Self as MapProperties>::Key> {
+            self.keys()
+        }
 
         fn values_property(&self) -> impl Iterator<Item = &Self::Value> {
             self.values()
+        }
+
+        fn entries_property(&self) -> impl Iterator<Item = (&Self::Key, &Self::Value)> {
+            self.iter()
         }
     }
 }
 
 #[cfg(feature = "std")]
 mod std_hashmap_impls {
-    use crate::properties::{KeysProperty, ValuesProperty};
+    use crate::properties::MapProperties;
     use crate::std::iter::Iterator;
     use std::collections::HashMap;
 
-    impl<K, V, H> KeysProperty for HashMap<K, V, H> {
+    impl<K, V, H> MapProperties for HashMap<K, V, H> {
         type Key = K;
-
-        fn keys_property(&self) -> impl Iterator<Item = &<Self as KeysProperty>::Key> {
-            self.keys()
-        }
-    }
-
-    impl<K, V, H> KeysProperty for &HashMap<K, V, H> {
-        type Key = K;
-
-        fn keys_property(&self) -> impl Iterator<Item = &Self::Key> {
-            self.keys()
-        }
-    }
-
-    impl<K, V, H> KeysProperty for &mut HashMap<K, V, H> {
-        type Key = K;
-
-        fn keys_property(&self) -> impl Iterator<Item = &Self::Key> {
-            self.keys()
-        }
-    }
-
-    impl<K, V, H> ValuesProperty for HashMap<K, V, H> {
         type Value = V;
+
+        fn keys_property(&self) -> impl Iterator<Item = &<Self as MapProperties>::Key> {
+            self.keys()
+        }
 
         fn values_property(&self) -> impl Iterator<Item = &Self::Value> {
             self.values()
         }
+
+        fn entries_property(&self) -> impl Iterator<Item = (&Self::Key, &Self::Value)> {
+            self.iter()
+        }
     }
 
-    impl<K, V, H> ValuesProperty for &HashMap<K, V, H> {
+    impl<K, V, H> MapProperties for &HashMap<K, V, H> {
+        type Key = K;
         type Value = V;
+
+        fn keys_property(&self) -> impl Iterator<Item = &<Self as MapProperties>::Key> {
+            self.keys()
+        }
 
         fn values_property(&self) -> impl Iterator<Item = &Self::Value> {
             self.values()
         }
+
+        fn entries_property(&self) -> impl Iterator<Item = (&Self::Key, &Self::Value)> {
+            self.iter()
+        }
     }
 
-    impl<K, V, H> ValuesProperty for &mut HashMap<K, V, H> {
+    impl<K, V, H> MapProperties for &mut HashMap<K, V, H> {
+        type Key = K;
         type Value = V;
+
+        fn keys_property(&self) -> impl Iterator<Item = &<Self as MapProperties>::Key> {
+            self.keys()
+        }
 
         fn values_property(&self) -> impl Iterator<Item = &Self::Value> {
             self.values()
+        }
+
+        fn entries_property(&self) -> impl Iterator<Item = (&Self::Key, &Self::Value)> {
+            self.iter()
         }
     }
 }
 
 mod btree_map_impls {
-    use crate::properties::{KeysProperty, ValuesProperty};
+    use crate::properties::MapProperties;
     use crate::std::collections::BTreeMap;
     use crate::std::iter::Iterator;
 
-    impl<K, V> KeysProperty for BTreeMap<K, V> {
+    impl<K, V> MapProperties for BTreeMap<K, V> {
         type Key = K;
-
-        fn keys_property(&self) -> impl Iterator<Item = &Self::Key> {
-            self.keys()
-        }
-    }
-
-    impl<K, V> KeysProperty for &BTreeMap<K, V> {
-        type Key = K;
-
-        fn keys_property(&self) -> impl Iterator<Item = &Self::Key> {
-            self.keys()
-        }
-    }
-
-    impl<K, V> KeysProperty for &mut BTreeMap<K, V> {
-        type Key = K;
-
-        fn keys_property(&self) -> impl Iterator<Item = &Self::Key> {
-            self.keys()
-        }
-    }
-
-    impl<K, V> ValuesProperty for BTreeMap<K, V> {
         type Value = V;
+
+        fn keys_property(&self) -> impl Iterator<Item = &<Self as MapProperties>::Key> {
+            self.keys()
+        }
 
         fn values_property(&self) -> impl Iterator<Item = &Self::Value> {
             self.values()
         }
+
+        fn entries_property(&self) -> impl Iterator<Item = (&Self::Key, &Self::Value)> {
+            self.iter()
+        }
     }
 
-    impl<K, V> ValuesProperty for &BTreeMap<K, V> {
+    impl<K, V> MapProperties for &BTreeMap<K, V> {
+        type Key = K;
         type Value = V;
+
+        fn keys_property(&self) -> impl Iterator<Item = &<Self as MapProperties>::Key> {
+            self.keys()
+        }
 
         fn values_property(&self) -> impl Iterator<Item = &Self::Value> {
             self.values()
         }
+
+        fn entries_property(&self) -> impl Iterator<Item = (&Self::Key, &Self::Value)> {
+            self.iter()
+        }
     }
 
-    impl<K, V> ValuesProperty for &mut BTreeMap<K, V> {
+    impl<K, V> MapProperties for &mut BTreeMap<K, V> {
+        type Key = K;
         type Value = V;
+
+        fn keys_property(&self) -> impl Iterator<Item = &<Self as MapProperties>::Key> {
+            self.keys()
+        }
 
         fn values_property(&self) -> impl Iterator<Item = &Self::Value> {
             self.values()
+        }
+
+        fn entries_property(&self) -> impl Iterator<Item = (&Self::Key, &Self::Value)> {
+            self.iter()
         }
     }
 }

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -1,0 +1,282 @@
+use crate::assertions::{AssertMapContainsKey, AssertMapContainsValue};
+use crate::colored::{mark_missing, mark_unexpected};
+use crate::expectations::{MapContainsKey, MapContainsValue, Negatable, Not};
+use crate::properties::{KeysProperty, ValuesProperty};
+use crate::spec::{DiffFormat, Expectation, Expression, FailingStrategy, Spec};
+use crate::std::fmt::Debug;
+use crate::std::format;
+use crate::std::string::String;
+
+impl<S, E, R> AssertMapContainsKey<E> for Spec<'_, S, R>
+where
+    S: KeysProperty + Debug,
+    <S as KeysProperty>::Key: PartialEq<E>,
+    E: Debug,
+    R: FailingStrategy,
+{
+    fn contains_key(self, expected_key: E) -> Self {
+        self.expecting(MapContainsKey { expected_key })
+    }
+
+    fn does_not_contain_key(self, expected_key: E) -> Self {
+        self.expecting(Not(MapContainsKey { expected_key }))
+    }
+}
+
+impl<M, E> Expectation<M> for MapContainsKey<E>
+where
+    M: KeysProperty + Debug,
+    <M as KeysProperty>::Key: PartialEq<E>,
+    E: Debug,
+{
+    fn test(&mut self, subject: &M) -> bool {
+        subject.keys_property().any(|k| k == &self.expected_key)
+    }
+
+    fn message(&self, expression: Expression<'_>, actual: &M, format: &DiffFormat) -> String {
+        let expected_key = &self.expected_key;
+        let marked_actual = mark_unexpected(actual, format);
+        let marked_expected = mark_missing(&self.expected_key, format);
+
+        format!("expected {expression} contains key {expected_key:?}\n   but was: {marked_actual}\n  expected: {marked_expected}")
+    }
+}
+
+impl<S, E> Negatable<S> for MapContainsKey<E>
+where
+    S: Debug,
+    E: Debug,
+{
+    fn negated_message(
+        &self,
+        expression: Expression<'_>,
+        actual: &S,
+        format: &DiffFormat,
+    ) -> String {
+        let expected_key = &self.expected_key;
+        let marked_actual = mark_unexpected(actual, format);
+        let marked_expected = mark_missing(&self.expected_key, format);
+
+        format!("expected {expression} does not contain key {expected_key:?}\n   but was: {marked_actual}\n  expected: {marked_expected}")
+    }
+}
+
+impl<S, E, R> AssertMapContainsValue<E> for Spec<'_, S, R>
+where
+    S: ValuesProperty + Debug,
+    <S as ValuesProperty>::Value: PartialEq<E>,
+    E: Debug,
+    R: FailingStrategy,
+{
+    fn contains_value(self, expected_value: E) -> Self {
+        self.expecting(MapContainsValue { expected_value })
+    }
+
+    fn does_not_contain_value(self, expected_value: E) -> Self {
+        self.expecting(Not(MapContainsValue { expected_value }))
+    }
+}
+
+impl<M, E> Expectation<M> for MapContainsValue<E>
+where
+    M: ValuesProperty + Debug,
+    <M as ValuesProperty>::Value: PartialEq<E>,
+    E: Debug,
+{
+    fn test(&mut self, subject: &M) -> bool {
+        subject.values_property().any(|v| v == &self.expected_value)
+    }
+
+    fn message(&self, expression: Expression<'_>, actual: &M, format: &DiffFormat) -> String {
+        let expected_value = &self.expected_value;
+        let marked_actual = mark_unexpected(actual, format);
+        let marked_expected = mark_missing(&self.expected_value, format);
+
+        format!("expected {expression} contains value {expected_value:?}\n   but was: {marked_actual}\n  expected: {marked_expected}")
+    }
+}
+
+impl<S, E> Negatable<S> for MapContainsValue<E>
+where
+    S: Debug,
+    E: Debug,
+{
+    fn negated_message(
+        &self,
+        expression: Expression<'_>,
+        actual: &S,
+        format: &DiffFormat,
+    ) -> String {
+        let expected_value = &self.expected_value;
+        let marked_actual = mark_unexpected(actual, format);
+        let marked_expected = mark_missing(&self.expected_value, format);
+
+        format!("expected {expression} does not contain value {expected_value:?}\n   but was: {marked_actual}\n  expected: {marked_expected}")
+    }
+}
+
+mod hashbrown_impls {
+    use crate::properties::{KeysProperty, ValuesProperty};
+    use crate::std::iter::Iterator;
+    use hashbrown::HashMap;
+
+    impl<K, V, H> KeysProperty for HashMap<K, V, H> {
+        type Key = K;
+
+        fn keys_property(&self) -> impl Iterator<Item = &<Self as KeysProperty>::Key> {
+            self.keys()
+        }
+    }
+
+    impl<K, V, H> KeysProperty for &HashMap<K, V, H> {
+        type Key = K;
+
+        fn keys_property(&self) -> impl Iterator<Item = &Self::Key> {
+            self.keys()
+        }
+    }
+
+    impl<K, V, H> KeysProperty for &mut HashMap<K, V, H> {
+        type Key = K;
+
+        fn keys_property(&self) -> impl Iterator<Item = &Self::Key> {
+            self.keys()
+        }
+    }
+
+    impl<K, V, H> ValuesProperty for HashMap<K, V, H> {
+        type Value = V;
+
+        fn values_property(&self) -> impl Iterator<Item = &Self::Value> {
+            self.values()
+        }
+    }
+
+    impl<K, V, H> ValuesProperty for &HashMap<K, V, H> {
+        type Value = V;
+
+        fn values_property(&self) -> impl Iterator<Item = &Self::Value> {
+            self.values()
+        }
+    }
+
+    impl<K, V, H> ValuesProperty for &mut HashMap<K, V, H> {
+        type Value = V;
+
+        fn values_property(&self) -> impl Iterator<Item = &Self::Value> {
+            self.values()
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+mod std_hashmap_impls {
+    use crate::properties::{KeysProperty, ValuesProperty};
+    use crate::std::iter::Iterator;
+    use std::collections::HashMap;
+
+    impl<K, V, H> KeysProperty for HashMap<K, V, H> {
+        type Key = K;
+
+        fn keys_property(&self) -> impl Iterator<Item = &<Self as KeysProperty>::Key> {
+            self.keys()
+        }
+    }
+
+    impl<K, V, H> KeysProperty for &HashMap<K, V, H> {
+        type Key = K;
+
+        fn keys_property(&self) -> impl Iterator<Item = &Self::Key> {
+            self.keys()
+        }
+    }
+
+    impl<K, V, H> KeysProperty for &mut HashMap<K, V, H> {
+        type Key = K;
+
+        fn keys_property(&self) -> impl Iterator<Item = &Self::Key> {
+            self.keys()
+        }
+    }
+
+    impl<K, V, H> ValuesProperty for HashMap<K, V, H> {
+        type Value = V;
+
+        fn values_property(&self) -> impl Iterator<Item = &Self::Value> {
+            self.values()
+        }
+    }
+
+    impl<K, V, H> ValuesProperty for &HashMap<K, V, H> {
+        type Value = V;
+
+        fn values_property(&self) -> impl Iterator<Item = &Self::Value> {
+            self.values()
+        }
+    }
+
+    impl<K, V, H> ValuesProperty for &mut HashMap<K, V, H> {
+        type Value = V;
+
+        fn values_property(&self) -> impl Iterator<Item = &Self::Value> {
+            self.values()
+        }
+    }
+}
+
+mod btree_map_impls {
+    use crate::properties::{KeysProperty, ValuesProperty};
+    use crate::std::collections::BTreeMap;
+    use crate::std::iter::Iterator;
+
+    impl<K, V> KeysProperty for BTreeMap<K, V> {
+        type Key = K;
+
+        fn keys_property(&self) -> impl Iterator<Item = &Self::Key> {
+            self.keys()
+        }
+    }
+
+    impl<K, V> KeysProperty for &BTreeMap<K, V> {
+        type Key = K;
+
+        fn keys_property(&self) -> impl Iterator<Item = &Self::Key> {
+            self.keys()
+        }
+    }
+
+    impl<K, V> KeysProperty for &mut BTreeMap<K, V> {
+        type Key = K;
+
+        fn keys_property(&self) -> impl Iterator<Item = &Self::Key> {
+            self.keys()
+        }
+    }
+
+    impl<K, V> ValuesProperty for BTreeMap<K, V> {
+        type Value = V;
+
+        fn values_property(&self) -> impl Iterator<Item = &Self::Value> {
+            self.values()
+        }
+    }
+
+    impl<K, V> ValuesProperty for &BTreeMap<K, V> {
+        type Value = V;
+
+        fn values_property(&self) -> impl Iterator<Item = &Self::Value> {
+            self.values()
+        }
+    }
+
+    impl<K, V> ValuesProperty for &mut BTreeMap<K, V> {
+        type Value = V;
+
+        fn values_property(&self) -> impl Iterator<Item = &Self::Value> {
+            self.values()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/map/tests.rs
+++ b/src/map/tests.rs
@@ -1,0 +1,576 @@
+mod hashbrown {
+    use crate::prelude::*;
+    use crate::std::format;
+    use hashbrown::HashMap;
+
+    #[test]
+    fn hashmap_is_empty() {
+        let subject: HashMap<usize, &str> = HashMap::new();
+
+        assert_that(subject).is_empty();
+    }
+
+    #[test]
+    fn hashmap_is_not_empty() {
+        let subject: HashMap<_, _> = [(5, "five")].into();
+
+        assert_that(subject).is_not_empty();
+    }
+
+    #[test]
+    fn hashmap_has_length() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(subject).has_length(3);
+    }
+
+    #[test]
+    fn hashmap_has_length_in_range() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(&subject).has_length_in_range(3..4);
+        assert_that(&subject).has_length_in_range(3..=4);
+    }
+
+    #[test]
+    fn hashmap_contains_key_value_pair() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(subject).contains((5, "five"));
+    }
+
+    #[test]
+    fn borrowed_hashmap_contains_key_value_pair() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(&subject).contains((&5, &"five"));
+    }
+
+    #[test]
+    fn mutable_borrowed_hashmap_contains_key_value_pair() {
+        let mut subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(&mut subject).contains((&5, &mut "five"));
+    }
+
+    #[test]
+    fn hashmap_contains_key() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(subject).contains_key(5);
+    }
+
+    #[test]
+    fn borrowed_hashmap_contains_key() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(&subject).contains_key(5);
+    }
+
+    #[test]
+    fn mutable_borrowed_hashmap_contains_key() {
+        let mut subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(&mut subject).contains_key(5);
+    }
+
+    #[test]
+    fn verify_hashmap_contains_key_fails() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+        let formatted_actual = format!("{:?}", &subject);
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .contains_key(7)
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                r"assertion failed: expected foo_map contains key 7
+   but was: {formatted_actual}
+  expected: 7
+"
+            )]
+        );
+    }
+
+    #[test]
+    fn hashmap_does_not_contain_key() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(subject).does_not_contain_key(6);
+    }
+
+    #[test]
+    fn verify_hashmap_does_not_contain_key_fails() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+        let formatted_actual = format!("{:?}", &subject);
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .does_not_contain_key(5)
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                r"assertion failed: expected foo_map does not contain key 5
+   but was: {formatted_actual}
+  expected: 5
+"
+            )]
+        );
+    }
+
+    #[test]
+    fn hashmap_map_contains_value() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(subject).contains_value("four");
+    }
+
+    #[test]
+    fn borrowed_hashmap_map_contains_value() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(&subject).contains_value("four");
+    }
+
+    #[test]
+    fn mutable_borrowed_hashmap_map_contains_value() {
+        let mut subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(&mut subject).contains_value("four");
+    }
+
+    #[test]
+    fn verify_hashmap_contains_value_fails() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+        let formatted_actual = format!("{:?}", &subject);
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .contains_value("six")
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                r#"assertion failed: expected foo_map contains value "six"
+   but was: {formatted_actual}
+  expected: "six"
+"#
+            )]
+        );
+    }
+
+    #[test]
+    fn hashmap_map_does_not_contain_value() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(subject).does_not_contain_value("six");
+    }
+
+    #[test]
+    fn verify_hashmap_does_not_contain_value_fails() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+        let formatted_actual = format!("{:?}", &subject);
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .does_not_contain_value("five")
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                r#"assertion failed: expected foo_map does not contain value "five"
+   but was: {formatted_actual}
+  expected: "five"
+"#
+            )]
+        );
+    }
+}
+
+#[cfg(feature = "std")]
+mod std_hash_map {
+    use crate::prelude::*;
+    use crate::std::collections::HashMap;
+
+    #[test]
+    fn hashmap_is_empty() {
+        let subject: HashMap<usize, &str> = HashMap::new();
+
+        assert_that(subject).is_empty();
+    }
+
+    #[test]
+    fn hashmap_is_not_empty() {
+        let subject: HashMap<_, _> = [(5, "five")].into();
+
+        assert_that(subject).is_not_empty();
+    }
+
+    #[test]
+    fn hashmap_has_length() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(subject).has_length(3);
+    }
+
+    #[test]
+    fn hashmap_has_length_in_range() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(&subject).has_length_in_range(3..4);
+        assert_that(&subject).has_length_in_range(3..=4);
+    }
+
+    #[test]
+    fn hashmap_contains_key_value_pair() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(subject).contains((4, "four"));
+    }
+
+    #[test]
+    fn borrowed_hashmap_contains_key_value_pair() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(&subject).contains((&4, &"four"));
+    }
+
+    #[test]
+    fn mutable_borrowed_hashmap_contains_key_value_pair() {
+        let mut subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(&mut subject).contains((&4, &mut "four"));
+    }
+
+    #[test]
+    fn hashmap_contains_key() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(subject).contains_key(5);
+    }
+
+    #[test]
+    fn borrowed_hashmap_contains_key() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(&subject).contains_key(5);
+    }
+
+    #[test]
+    fn mutably_borrowed_hashmap_contains_key() {
+        let mut subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(&mut subject).contains_key(5);
+    }
+
+    #[test]
+    fn verify_hashmap_contains_key_fails() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+        let formatted_actual = format!("{:?}", &subject);
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .contains_key(7)
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                r"assertion failed: expected foo_map contains key 7
+   but was: {formatted_actual}
+  expected: 7
+"
+            )]
+        );
+    }
+
+    #[test]
+    fn hashmap_does_not_contain_key() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(subject).does_not_contain_key(6);
+    }
+
+    #[test]
+    fn verify_hashmap_does_not_contain_key_fails() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+        let formatted_actual = format!("{:?}", &subject);
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .does_not_contain_key(4)
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                r"assertion failed: expected foo_map does not contain key 4
+   but was: {formatted_actual}
+  expected: 4
+"
+            )]
+        );
+    }
+
+    #[test]
+    fn hashmap_map_contains_value() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(subject).contains_value("four");
+    }
+
+    #[test]
+    fn borrowed_hashmap_map_contains_value() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(&subject).contains_value("four");
+    }
+
+    #[test]
+    fn mutable_borrowed_hashmap_map_contains_value() {
+        let mut subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(&mut subject).contains_value("four");
+    }
+
+    #[test]
+    fn verify_hashmap_contains_value_fails() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+        let formatted_actual = format!("{:?}", &subject);
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .contains_value("six")
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                r#"assertion failed: expected foo_map contains value "six"
+   but was: {formatted_actual}
+  expected: "six"
+"#
+            )]
+        );
+    }
+
+    #[test]
+    fn hashmap_map_does_not_contain_value() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(subject).does_not_contain_value("six");
+    }
+
+    #[test]
+    fn verify_hashmap_does_not_contain_value_fails() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+        let formatted_actual = format!("{:?}", &subject);
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .does_not_contain_value("four")
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                r#"assertion failed: expected foo_map does not contain value "four"
+   but was: {formatted_actual}
+  expected: "four"
+"#
+            )]
+        );
+    }
+}
+
+mod btree_map {
+    use crate::prelude::*;
+    use crate::std::collections::BTreeMap;
+
+    #[test]
+    fn btree_map_is_empty() {
+        let subject: BTreeMap<usize, &str> = BTreeMap::new();
+
+        assert_that(subject).is_empty();
+    }
+
+    #[test]
+    fn hashmap_is_not_empty() {
+        let subject: BTreeMap<_, _> = [(5, "five")].into();
+
+        assert_that(subject).is_not_empty();
+    }
+
+    #[test]
+    fn btree_map_has_length() {
+        let subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(subject).has_length(3);
+    }
+
+    #[test]
+    fn btree_map_has_length_in_range() {
+        let subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(&subject).has_length_in_range(3..4);
+        assert_that(&subject).has_length_in_range(3..=4);
+    }
+
+    #[test]
+    fn btree_map_contains_key_value_pair() {
+        let subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(subject).contains((1, "one"));
+    }
+
+    #[test]
+    fn borrowed_btree_map_contains_key_value_pair() {
+        let subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(&subject).contains((&1, &"one"));
+    }
+
+    #[test]
+    fn mutable_borrowed_btree_map_contains_key_value_pair() {
+        let mut subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(&mut subject).contains((&1, &mut "one"));
+    }
+
+    #[test]
+    fn btree_map_contains_key() {
+        let subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(subject).contains_key(5);
+    }
+
+    #[test]
+    fn borrowed_btree_map_contains_key() {
+        let subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(&subject).contains_key(5);
+    }
+
+    #[test]
+    fn mutable_borrowed_btree_map_contains_key() {
+        let mut subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(&mut subject).contains_key(5);
+    }
+
+    #[test]
+    fn verify_btree_map_contains_key_fails() {
+        let subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .contains_key(7)
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[r#"assertion failed: expected foo_map contains key 7
+   but was: {1: "one", 4: "four", 5: "five"}
+  expected: 7
+"#]
+        );
+    }
+
+    #[test]
+    fn btree_map_does_not_contain_key() {
+        let subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(subject).does_not_contain_key(6);
+    }
+
+    #[test]
+    fn verify_btree_map_does_not_contain_key_fails() {
+        let subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .does_not_contain_key(1)
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[r#"assertion failed: expected foo_map does not contain key 1
+   but was: {1: "one", 4: "four", 5: "five"}
+  expected: 1
+"#]
+        );
+    }
+
+    #[test]
+    fn btree_map_contains_value() {
+        let subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(subject).contains_value("four");
+    }
+
+    #[test]
+    fn borrowed_btree_map_contains_value() {
+        let subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(&subject).contains_value("four");
+    }
+
+    #[test]
+    fn mutable_borrowed_btree_map_contains_value() {
+        let mut subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(&mut subject).contains_value("four");
+    }
+
+    #[test]
+    fn verify_btree_map_contains_value_fails() {
+        let subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .contains_value("six")
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[r#"assertion failed: expected foo_map contains value "six"
+   but was: {1: "one", 4: "four", 5: "five"}
+  expected: "six"
+"#]
+        );
+    }
+
+    #[test]
+    fn btree_map_does_not_contain_value() {
+        let subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        assert_that(subject).does_not_contain_value("six");
+    }
+
+    #[test]
+    fn verify_btree_map_does_not_contain_value_fails() {
+        let subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four")].into();
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .does_not_contain_value("one")
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[
+                r#"assertion failed: expected foo_map does not contain value "one"
+   but was: {1: "one", 4: "four", 5: "five"}
+  expected: "one"
+"#
+            ]
+        );
+    }
+}

--- a/src/map/tests.rs
+++ b/src/map/tests.rs
@@ -360,6 +360,43 @@ mod hashbrown {
             )]
         );
     }
+
+    #[test]
+    fn hashmap_contains_exactly_keys() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+
+        assert_that(subject).contains_exactly_keys([5, 6, 1, 4]);
+    }
+
+    #[test]
+    fn verify_hashmap_contains_exactly_keys_fails() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+        let formatted_actual = format!("{:?}", &subject);
+        let formatted_extra = format!(
+            "{:?}",
+            subject
+                .keys()
+                .filter(|k| **k == 1 || **k == 4)
+                .collect::<Vec<_>>()
+        );
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .contains_exactly_keys([5, 2, 6, 3])
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                r"assertion failed: expected foo_map contains exactly the keys [5, 2, 6, 3]
+   but was: {formatted_actual}
+  expected: [5, 2, 6, 3]
+   missing: [2, 3]
+     extra: {formatted_extra}
+"
+            )]
+        );
+    }
 }
 
 #[cfg(feature = "std")]
@@ -659,12 +696,43 @@ mod std_hash_map {
             )]
         );
     }
+
+    #[test]
+    fn hashmap_contains_exactly_keys() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+
+        assert_that(subject).contains_exactly_keys([5, 6, 1, 4]);
+    }
+
+    #[test]
+    fn verify_hashmap_contains_exactly_keys_fails() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+        let formatted_actual = format!("{:?}", &subject);
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .contains_exactly_keys([4, 5, 6, 3])
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                r"assertion failed: expected foo_map contains exactly the keys [4, 5, 6, 3]
+   but was: {formatted_actual}
+  expected: [4, 5, 6, 3]
+   missing: [3]
+     extra: [1]
+"
+            )]
+        );
+    }
 }
 
 mod btree_map {
     use crate::prelude::*;
     use crate::std::collections::BTreeMap;
     use crate::std::format;
+    use crate::std::vec::Vec;
 
     #[test]
     fn btree_map_is_empty() {
@@ -947,6 +1015,43 @@ mod btree_map {
             )]
         );
     }
+
+    #[test]
+    fn btree_map_contains_exactly_keys() {
+        let subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+
+        assert_that(subject).contains_exactly_keys([5, 6, 1, 4]);
+    }
+
+    #[test]
+    fn verify_btree_map_contains_exactly_keys_fails() {
+        let subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+        let formatted_actual = format!("{:?}", &subject);
+        let formatted_extra = format!(
+            "{:?}",
+            subject
+                .keys()
+                .filter(|k| **k == 1 || **k == 4)
+                .collect::<Vec<_>>()
+        );
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .contains_exactly_keys([5, 2, 6, 3])
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                r"assertion failed: expected foo_map contains exactly the keys [5, 2, 6, 3]
+   but was: {formatted_actual}
+  expected: [5, 2, 6, 3]
+   missing: [2, 3]
+     extra: {formatted_extra}
+"
+            )]
+        );
+    }
 }
 
 #[cfg(feature = "colored")]
@@ -1162,6 +1267,39 @@ mod colored {
                 "assertion failed: expected foo_map does not contain values [\"five\", \"two\", \"four\", \"seven\"]\n   \
                     but was: {formatted_actual}\n  \
                    expected: [\u{1b}[32m\"five\"\u{1b}[0m, \"two\", \u{1b}[32m\"four\"\u{1b}[0m, \"seven\"]\n     \
+                      extra: {formatted_extra}\n\
+                "
+            )]
+        );
+    }
+
+    #[test]
+    fn highlight_diffs_hashmap_contains_exactly_keys() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+        let formatted_actual = format!("{:?}", &subject)
+            .replace("1: \"one\"", "\u{1b}[31m1: \"one\"\u{1b}[0m")
+            .replace("4: \"four\"", "\u{1b}[31m4: \"four\"\u{1b}[0m");
+        let formatted_extra = format!(
+            "{:?}",
+            subject
+                .keys()
+                .filter(|k| **k == 1 || **k == 4)
+                .collect::<Vec<_>>()
+        );
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .with_diff_format(DIFF_FORMAT_RED_GREEN)
+            .contains_exactly_keys([5, 2, 6, 3])
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                "assertion failed: expected foo_map contains exactly the keys [5, 2, 6, 3]\n   \
+                    but was: {formatted_actual}\n  \
+                   expected: [5, \u{1b}[32m2\u{1b}[0m, 6, \u{1b}[32m3\u{1b}[0m]\n   \
+                    missing: [2, 3]\n     \
                       extra: {formatted_extra}\n\
                 "
             )]

--- a/src/map/tests.rs
+++ b/src/map/tests.rs
@@ -192,12 +192,115 @@ mod hashbrown {
             )]
         );
     }
+
+    #[test]
+    fn hashmap_contains_keys() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+
+        assert_that(subject).contains_keys([5, 4]);
+    }
+
+    #[test]
+    fn verify_hashmap_contains_keys_fails() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+        let formatted_actual = format!("{:?}", &subject);
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .contains_keys([5, 3, 4])
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                r"assertion failed: expected foo_map contains keys [5, 3, 4]
+   but was: {formatted_actual}
+  expected: [5, 3, 4]
+   missing: [3]
+"
+            )]
+        );
+    }
+
+    #[test]
+    fn verify_borrowed_hashmap_contains_keys_fails() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+        let formatted_actual = format!("{:?}", &subject);
+
+        let failures = verify_that(&subject)
+            .named("foo_map")
+            .contains_keys([5, 3, 4])
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                r"assertion failed: expected foo_map contains keys [5, 3, 4]
+   but was: {formatted_actual}
+  expected: [5, 3, 4]
+   missing: [3]
+"
+            )]
+        );
+    }
+
+    #[test]
+    fn verify_mutable_borrowed_hashmap_contains_keys_fails() {
+        let mut subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+        let formatted_actual = format!("{:?}", &subject);
+
+        let failures = verify_that(&mut subject)
+            .named("foo_map")
+            .contains_keys([5, 3, 4])
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                r"assertion failed: expected foo_map contains keys [5, 3, 4]
+   but was: {formatted_actual}
+  expected: [5, 3, 4]
+   missing: [3]
+"
+            )]
+        );
+    }
+
+    #[test]
+    fn hashmap_contains_values() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+
+        assert_that(subject).contains_values(["five", "four"]);
+    }
+
+    #[test]
+    fn verify_hashmap_contains_values_fails() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+        let formatted_actual = format!("{:?}", &subject);
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .contains_values(["one", "two", "three"])
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                r#"assertion failed: expected foo_map contains values ["one", "two", "three"]
+   but was: {formatted_actual}
+  expected: ["one", "two", "three"]
+   missing: ["two", "three"]
+"#
+            )]
+        );
+    }
 }
 
 #[cfg(feature = "std")]
 mod std_hash_map {
     use crate::prelude::*;
     use crate::std::collections::HashMap;
+    use crate::std::format;
 
     #[test]
     fn hashmap_is_empty() {
@@ -388,11 +491,114 @@ mod std_hash_map {
             )]
         );
     }
+
+    #[test]
+    fn hashmap_contains_keys() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+
+        assert_that(subject).contains_keys([1, 6]);
+    }
+
+    #[test]
+    fn verify_hashmap_contains_keys_fails() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+        let formatted_actual = format!("{:?}", &subject);
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .contains_keys([2, 3, 5])
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                r"assertion failed: expected foo_map contains keys [2, 3, 5]
+   but was: {formatted_actual}
+  expected: [2, 3, 5]
+   missing: [2, 3]
+"
+            )]
+        );
+    }
+
+    #[test]
+    fn verify_borrowed_hashmap_contains_keys_fails() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+        let formatted_actual = format!("{:?}", &subject);
+
+        let failures = verify_that(&subject)
+            .named("foo_map")
+            .contains_keys([2, 3, 5])
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                r"assertion failed: expected foo_map contains keys [2, 3, 5]
+   but was: {formatted_actual}
+  expected: [2, 3, 5]
+   missing: [2, 3]
+"
+            )]
+        );
+    }
+
+    #[test]
+    fn verify_mutable_borrowed_hashmap_contains_keys_fails() {
+        let mut subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+        let formatted_actual = format!("{:?}", &subject);
+
+        let failures = verify_that(&mut subject)
+            .named("foo_map")
+            .contains_keys([2, 3, 5])
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                r"assertion failed: expected foo_map contains keys [2, 3, 5]
+   but was: {formatted_actual}
+  expected: [2, 3, 5]
+   missing: [2, 3]
+"
+            )]
+        );
+    }
+
+    #[test]
+    fn hashmap_contains_values() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+
+        assert_that(subject).contains_values(["five", "four"]);
+    }
+
+    #[test]
+    fn verify_hashmap_contains_values_fails() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+        let formatted_actual = format!("{:?}", &subject);
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .contains_values(["one", "two", "three"])
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                r#"assertion failed: expected foo_map contains values ["one", "two", "three"]
+   but was: {formatted_actual}
+  expected: ["one", "two", "three"]
+   missing: ["two", "three"]
+"#
+            )]
+        );
+    }
 }
 
 mod btree_map {
     use crate::prelude::*;
     use crate::std::collections::BTreeMap;
+    use crate::std::format;
 
     #[test]
     fn btree_map_is_empty() {
@@ -571,6 +777,263 @@ mod btree_map {
   expected: "one"
 "#
             ]
+        );
+    }
+
+    #[test]
+    fn btree_map_contains_keys() {
+        let subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+
+        assert_that(subject).contains_keys([5, 1, 6]);
+    }
+
+    #[test]
+    fn verify_btree_map_contains_keys_fails() {
+        let subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+        let formatted_actual = format!("{:?}", &subject);
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .contains_keys([5, 3, 7])
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                r"assertion failed: expected foo_map contains keys [5, 3, 7]
+   but was: {formatted_actual}
+  expected: [5, 3, 7]
+   missing: [3, 7]
+"
+            )]
+        );
+    }
+
+    #[test]
+    fn verify_borrowed_btree_map_contains_keys_fails() {
+        let subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+        let formatted_actual = format!("{:?}", &subject);
+
+        let failures = verify_that(&subject)
+            .named("foo_map")
+            .contains_keys([5, 3, 7])
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                r"assertion failed: expected foo_map contains keys [5, 3, 7]
+   but was: {formatted_actual}
+  expected: [5, 3, 7]
+   missing: [3, 7]
+"
+            )]
+        );
+    }
+
+    #[test]
+    fn verify_mutable_borrowed_btree_map_contains_keys_fails() {
+        let mut subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+        let formatted_actual = format!("{:?}", &subject);
+
+        let failures = verify_that(&mut subject)
+            .named("foo_map")
+            .contains_keys([5, 3, 7])
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                r"assertion failed: expected foo_map contains keys [5, 3, 7]
+   but was: {formatted_actual}
+  expected: [5, 3, 7]
+   missing: [3, 7]
+"
+            )]
+        );
+    }
+
+    #[test]
+    fn btree_map_contains_values() {
+        let subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+
+        assert_that(subject).contains_values(["five", "four"]);
+    }
+
+    #[test]
+    fn verify_btree_map_contains_values_fails() {
+        let subject: BTreeMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+        let formatted_actual = format!("{:?}", &subject);
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .contains_values(["one", "two", "three"])
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                r#"assertion failed: expected foo_map contains values ["one", "two", "three"]
+   but was: {formatted_actual}
+  expected: ["one", "two", "three"]
+   missing: ["two", "three"]
+"#
+            )]
+        );
+    }
+}
+
+#[cfg(feature = "colored")]
+mod colored {
+    use crate::prelude::*;
+    use crate::std::format;
+    use hashbrown::HashMap;
+
+    #[test]
+    fn highlight_diffs_hashmap_contains_key() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+        let formatted_actual = format!("{:?}", &subject)
+            .replace("5: \"five\"", "\u{1b}[31m5: \"five\"\u{1b}[0m")
+            .replace("1: \"one\"", "\u{1b}[31m1: \"one\"\u{1b}[0m")
+            .replace("4: \"four\"", "\u{1b}[31m4: \"four\"\u{1b}[0m")
+            .replace("6: \"six\"", "\u{1b}[31m6: \"six\"\u{1b}[0m");
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .with_diff_format(DIFF_FORMAT_RED_GREEN)
+            .contains_key(2)
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                "assertion failed: expected foo_map contains key 2\n   \
+                but was: {formatted_actual}\n  \
+               expected: \u{1b}[32m2\u{1b}[0m\n\
+            "
+            )]
+        );
+    }
+
+    #[test]
+    fn highlight_diffs_hashmap_does_not_contain_key() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+        let formatted_actual =
+            format!("{:?}", &subject).replace("1: \"one\"", "\u{1b}[31m1: \"one\"\u{1b}[0m");
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .with_diff_format(DIFF_FORMAT_RED_GREEN)
+            .does_not_contain_key(1)
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                "assertion failed: expected foo_map does not contain key 1\n   \
+                but was: {formatted_actual}\n  \
+               expected: \u{1b}[32m1\u{1b}[0m\n\
+            "
+            )]
+        );
+    }
+
+    #[test]
+    fn highlight_diffs_hashmap_contains_value() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+        let formatted_actual = format!("{:?}", &subject)
+            .replace("5: \"five\"", "\u{1b}[31m5: \"five\"\u{1b}[0m")
+            .replace("1: \"one\"", "\u{1b}[31m1: \"one\"\u{1b}[0m")
+            .replace("4: \"four\"", "\u{1b}[31m4: \"four\"\u{1b}[0m")
+            .replace("6: \"six\"", "\u{1b}[31m6: \"six\"\u{1b}[0m");
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .with_diff_format(DIFF_FORMAT_RED_GREEN)
+            .contains_value("three")
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                "assertion failed: expected foo_map contains value \"three\"\n   \
+                but was: {formatted_actual}\n  \
+               expected: \u{1b}[32m\"three\"\u{1b}[0m\n\
+            "
+            )]
+        );
+    }
+
+    #[test]
+    fn highlight_diffs_hashmap_does_not_contain_value() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+        let formatted_actual =
+            format!("{:?}", &subject).replace("4: \"four\"", "\u{1b}[31m4: \"four\"\u{1b}[0m");
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .with_diff_format(DIFF_FORMAT_RED_GREEN)
+            .does_not_contain_value("four")
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                "assertion failed: expected foo_map does not contain value \"four\"\n   \
+                but was: {formatted_actual}\n  \
+               expected: \u{1b}[32m\"four\"\u{1b}[0m\n\
+            "
+            )]
+        );
+    }
+
+    #[test]
+    fn highlight_diffs_hashmap_contains_keys() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+        let formatted_actual = format!("{:?}", &subject)
+            .replace("1: \"one\"", "\u{1b}[31m1: \"one\"\u{1b}[0m")
+            .replace("6: \"six\"", "\u{1b}[31m6: \"six\"\u{1b}[0m");
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .with_diff_format(DIFF_FORMAT_RED_GREEN)
+            .contains_keys([5, 2, 4, 7])
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                "assertion failed: expected foo_map contains keys [5, 2, 4, 7]\n   \
+                but was: {formatted_actual}\n  \
+               expected: [5, \u{1b}[32m2\u{1b}[0m, 4, \u{1b}[32m7\u{1b}[0m]\n   \
+                missing: [2, 7]\n\
+            "
+            )]
+        );
+    }
+
+    #[test]
+    fn highlight_diffs_hashmap_contains_values() {
+        let subject: HashMap<_, _> = [(5, "five"), (1, "one"), (4, "four"), (6, "six")].into();
+        let formatted_actual = format!("{:?}", &subject)
+            .replace("1: \"one\"", "\u{1b}[31m1: \"one\"\u{1b}[0m")
+            .replace("6: \"six\"", "\u{1b}[31m6: \"six\"\u{1b}[0m");
+
+        let failures = verify_that(subject)
+            .named("foo_map")
+            .with_diff_format(DIFF_FORMAT_RED_GREEN)
+            .contains_values(["five", "two", "four", "seven"])
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[format!(
+                "assertion failed: expected foo_map contains values [\"five\", \"two\", \"four\", \"seven\"]\n   \
+                    but was: {formatted_actual}\n  \
+                   expected: [\"five\", \u{1b}[32m\"two\"\u{1b}[0m, \"four\", \u{1b}[32m\"seven\"\u{1b}[0m]\n   \
+                    missing: [\"two\", \"seven\"]\n\
+                "
+            )]
         );
     }
 }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -220,21 +220,20 @@ where
     }
 }
 
-/// The keys property for map-like types provides access to the keys in a map.
-pub trait KeysProperty {
+/// The properties of a map-like type.
+pub trait MapProperties {
     /// The type of the keys in this map.
     type Key;
 
-    /// Returns an iterator over the keys in this map.
-    fn keys_property(&self) -> impl Iterator<Item = &Self::Key>;
-}
-
-/// The values property for map-like types provides access to the values in a
-/// map.
-pub trait ValuesProperty {
     /// The type of the values in this map.
     type Value;
 
+    /// Returns an iterator over the keys in this map.
+    fn keys_property(&self) -> impl Iterator<Item = &Self::Key>;
+
     /// Returns an iterator over the values in this map.
     fn values_property(&self) -> impl Iterator<Item = &Self::Value>;
+
+    /// Returns an iterator over the key/value-pairs in this map.
+    fn entries_property(&self) -> impl Iterator<Item = (&Self::Key, &Self::Value)>;
 }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -23,6 +23,8 @@
 //! specifies that a collection's iterator yields the items in a well-defined
 //! order.
 
+use crate::std::iter::Iterator;
+
 /// The "empty" property of a collection-like type.
 ///
 /// This property is used by the implementation of the
@@ -216,4 +218,23 @@ where
     fn is_nan_property(&self) -> bool {
         <T as IsNanProperty>::is_nan_property(self)
     }
+}
+
+/// The keys property for map-like types provides access to the keys in a map.
+pub trait KeysProperty {
+    /// The type of the keys in this map.
+    type Key;
+
+    /// Returns an iterator over the keys in this map.
+    fn keys_property(&self) -> impl Iterator<Item = &Self::Key>;
+}
+
+/// The values property for map-like types provides access to the values in a
+/// map.
+pub trait ValuesProperty {
+    /// The type of the values in this map.
+    type Value;
+
+    /// Returns an iterator over the values in this map.
+    fn values_property(&self) -> impl Iterator<Item = &Self::Value>;
 }


### PR DESCRIPTION
Provide assertions for keys an values in map-like types.

Implemented the assertions `contains_key`, `does_not_contain_key`, `contains_value`, `does_not_contain_value`, `contains_keys`, `does_not_contain_keys`, `contains_values`, `does_not_contain_values` and `contains_exactly_keys` for the types `std::collections::HashMap`, `std::collections::BTreeMap` and `hashbrown::HashMap`.