### PR TITLE
feat!: support dynamically composed `Expression`

### DIFF
--- a/src/boolean/mod.rs
+++ b/src/boolean/mod.rs
@@ -25,7 +25,7 @@ impl Expectation<bool> for IsTrue {
         *subject
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &bool, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &bool, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_expected = mark_missing(&true, format);
         format!(
@@ -40,7 +40,7 @@ impl Expectation<bool> for IsFalse {
         !*subject
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &bool, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &bool, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_expected = mark_missing(&false, format);
         format!(

--- a/src/char_count.rs
+++ b/src/char_count.rs
@@ -64,7 +64,7 @@ where
         subject.char_count_property() == self.expected_char_count
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(&actual.char_count_property(), format);
         let marked_expected = mark_missing(&self.expected_char_count, format);
         format!(
@@ -83,7 +83,7 @@ where
         self.expected_range.contains(&subject.char_count_property())
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(&actual.char_count_property(), format);
         let marked_expected = mark_missing(&self.expected_range, format);
         format!(
@@ -101,7 +101,7 @@ where
         subject.char_count_property() < self.expected_char_count
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(&actual.char_count_property(), format);
         let marked_expected = mark_missing(&self.expected_char_count, format);
         format!(
@@ -119,7 +119,7 @@ where
         subject.char_count_property() > self.expected_char_count
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(&actual.char_count_property(), format);
         let marked_expected = mark_missing(&self.expected_char_count, format);
         format!(
@@ -137,7 +137,7 @@ where
         subject.char_count_property() <= self.expected_char_count
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(&actual.char_count_property(), format);
         let marked_expected = mark_missing(&self.expected_char_count, format);
         format!(
@@ -155,7 +155,7 @@ where
         subject.char_count_property() >= self.expected_char_count
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(&actual.char_count_property(), format);
         let marked_expected = mark_missing(&self.expected_char_count, format);
         format!(

--- a/src/equality.rs
+++ b/src/equality.rs
@@ -31,7 +31,7 @@ where
         subject == &self.expected
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let expected = &self.expected;
         let (marked_actual, marked_expected) = mark_diff(actual, expected, format);
         format!(
@@ -49,7 +49,7 @@ where
         subject != &self.expected
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, _format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, _format: &DiffFormat) -> String {
         format!(
             "expected {expression} is not equal to {:?}\n   but was: {actual:?}\n  expected: {:?}",
             &self.expected, &self.expected

--- a/src/float/mod.rs
+++ b/src/float/mod.rs
@@ -145,7 +145,12 @@ mod cmp {
             subject.approx_eq(self.expected, self.margin)
         }
 
-        fn message(&self, expression: Expression<'_>, actual: &f32, format: &DiffFormat) -> String {
+        fn message(
+            &self,
+            expression: &Expression<'_>,
+            actual: &f32,
+            format: &DiffFormat,
+        ) -> String {
             let (marked_actual, marked_expected) = mark_diff(actual, &self.expected, format);
             format!("expected {expression} is close to {:?}\n  within a margin of epsilon={:e} and ulps={}\n   but was: {marked_actual}\n  expected: {marked_expected}",
                 &self.expected, self.margin.epsilon, self.margin.ulps
@@ -160,7 +165,7 @@ mod cmp {
 
         fn message(
             &self,
-            expression: Expression<'_>,
+            expression: &Expression<'_>,
             actual: &f32,
             _format: &DiffFormat,
         ) -> String {
@@ -175,7 +180,12 @@ mod cmp {
             subject.approx_eq(self.expected, self.margin)
         }
 
-        fn message(&self, expression: Expression<'_>, actual: &f64, format: &DiffFormat) -> String {
+        fn message(
+            &self,
+            expression: &Expression<'_>,
+            actual: &f64,
+            format: &DiffFormat,
+        ) -> String {
             let (marked_actual, marked_expected) = mark_diff(actual, &self.expected, format);
             format!("expected {expression} is close to {:?}\n  within a margin of epsilon={:e} and ulps={}\n   but was: {marked_actual}\n  expected: {marked_expected}",
                 &self.expected, self.margin.epsilon, self.margin.ulps
@@ -190,7 +200,7 @@ mod cmp {
 
         fn message(
             &self,
-            expression: Expression<'_>,
+            expression: &Expression<'_>,
             actual: &f64,
             _format: &DiffFormat,
         ) -> String {

--- a/src/iterator/mod.rs
+++ b/src/iterator/mod.rs
@@ -41,7 +41,7 @@ where
         subject.iter().any(|e| e == &self.expected)
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
         let marked_actual = mark_all_items_in_collection(actual, format, mark_unexpected);
         let marked_expected = mark_missing(&self.expected, format);
         format!(
@@ -112,7 +112,7 @@ where
         extra.is_empty() && missing.is_empty()
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
         let missing = collect_selected_values(&self.missing, &self.expected);
         let extra = collect_selected_values(&self.extra, actual);
         let marked_actual =
@@ -145,7 +145,7 @@ where
         false
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
         let marked_actual = mark_all_items_in_collection(actual, format, mark_unexpected);
         let marked_expected = mark_all_items_in_collection(&self.expected, format, mark_missing);
         format!(
@@ -174,7 +174,7 @@ where
         missing.is_empty()
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
         let mut extra = HashSet::new();
         for (actual_index, actual) in actual.iter().enumerate() {
             if !self.expected.iter().any(|expected| actual == expected) {
@@ -214,7 +214,7 @@ where
         extra.is_empty()
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
         let mut missing = HashSet::new();
         for (expected_index, expected) in self.expected.iter().enumerate() {
             if !actual.iter().any(|value| value == expected) {
@@ -259,7 +259,7 @@ where
         duplicates.is_empty() && extra.is_empty()
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
         let actual_duplicates_and_extras = self.duplicates.union(&self.extra).copied().collect();
         let marked_actual = mark_selected_items_in_collection(
             actual,
@@ -378,7 +378,7 @@ where
         out_of_order.is_empty() && extra.is_empty() && missing.is_empty()
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
         let out_of_order = collect_selected_values(&self.out_of_order, actual);
         let mut expected_indices = self.missing.clone();
         for (expected_index, expected) in self.expected.iter().enumerate() {
@@ -477,7 +477,7 @@ where
         false
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
         let marked_actual =
             mark_selected_items_in_collection(actual, &self.extra, format, mark_unexpected);
         let marked_expected =
@@ -519,7 +519,7 @@ where
         missing.is_empty()
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
         let marked_expected =
             mark_selected_items_in_collection(&self.expected, &self.missing, format, mark_missing);
         let missing = collect_selected_values(&self.missing, &self.expected);
@@ -562,7 +562,7 @@ where
         extra.is_empty() && missing.is_empty()
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
         let marked_actual =
             mark_selected_items_in_collection(actual, &self.extra, format, mark_unexpected);
         let marked_expected =
@@ -609,7 +609,7 @@ where
         extra.is_empty() && missing.is_empty()
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &Vec<T>, format: &DiffFormat) -> String {
         let marked_actual =
             mark_selected_items_in_collection(actual, &self.extra, format, mark_unexpected);
         let marked_expected =

--- a/src/length.rs
+++ b/src/length.rs
@@ -34,7 +34,7 @@ where
         subject.is_empty_property()
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         format!("expected {expression} is empty\n   but was: {marked_actual}\n  expected: <empty>")
     }
@@ -48,7 +48,7 @@ where
         !subject.is_empty_property()
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         format!(
             "expected {expression} is not empty\n   but was: {marked_actual}\n  expected: <non-empty>",
@@ -97,7 +97,7 @@ where
         subject.length_property() == self.expected_length
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(&actual.length_property(), format);
         let marked_expected = mark_missing(&self.expected_length, format);
         format!(
@@ -116,7 +116,7 @@ where
         self.expected_range.contains(&subject.length_property())
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(&actual.length_property(), format);
         let marked_expected = mark_missing(&self.expected_range, format);
         format!(
@@ -134,7 +134,7 @@ where
         subject.length_property() < self.expected_length
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(&actual.length_property(), format);
         let marked_expected = mark_missing(&self.expected_length, format);
         format!(
@@ -152,7 +152,7 @@ where
         subject.length_property() > self.expected_length
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(&actual.length_property(), format);
         let marked_expected = mark_missing(&self.expected_length, format);
         format!(
@@ -170,7 +170,7 @@ where
         subject.length_property() <= self.expected_length
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(&actual.length_property(), format);
         let marked_expected = mark_missing(&self.expected_length, format);
         format!(
@@ -188,7 +188,7 @@ where
         subject.length_property() >= self.expected_length
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(&actual.length_property(), format);
         let marked_expected = mark_missing(&self.expected_length, format);
         format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,7 +409,7 @@
 //!         }
 //!     }
 //!
-//!     fn message(&self, expression: Expression<'_>, actual: &Either<L, R>, _format: &DiffFormat) -> String {
+//!     fn message(&self, expression: &Expression<'_>, actual: &Either<L, R>, _format: &DiffFormat) -> String {
 //!         format!(
 //!             "expected {expression} is {:?}\n   but was: {actual:?}\n  expected: {:?}",
 //!             Either::Left::<_, Unknown>(Unknown),
@@ -446,7 +446,7 @@
 //! #         }
 //! #     }
 //! #
-//! #     fn message(&self, expression: Expression<'_>, actual: &Either<L, R>, _format: &DiffFormat) -> String {
+//! #     fn message(&self, expression: &Expression<'_>, actual: &Either<L, R>, _format: &DiffFormat) -> String {
 //! #         format!(
 //! #             "expected {expression} is {:?}\n   but was: {actual:?}\n  expected: {:?}",
 //! #             Either::Left::<_, Unknown>(Unknown),
@@ -493,7 +493,7 @@
 //! #         }
 //! #     }
 //! #
-//! #     fn message(&self, expression: Expression<'_>, actual: &Either<L, R>, _format: &DiffFormat) -> String {
+//! #     fn message(&self, expression: &Expression<'_>, actual: &Either<L, R>, _format: &DiffFormat) -> String {
 //! #         format!(
 //! #             "expected {expression} is {:?}\n   but was: {actual:?}\n  expected: {:?}",
 //! #             Either::Left::<_, Unknown>(Unknown),
@@ -547,7 +547,7 @@
 //! #         }
 //! #     }
 //! #
-//! #     fn message(&self, expression: Expression<'_>, actual: &Either<L, R>, _format: &DiffFormat) -> String {
+//! #     fn message(&self, expression: &Expression<'_>, actual: &Either<L, R>, _format: &DiffFormat) -> String {
 //! #         format!(
 //! #             "expected {expression} is {:?}\n   but was: {actual:?}\n  expected: {:?}",
 //! #             Either::Left::<_, Unknown>(Unknown),

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -56,7 +56,7 @@ where
         subject.keys_property().any(|k| k == &self.expected_key)
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &M, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &M, format: &DiffFormat) -> String {
         let expected_key = &self.expected_key;
         let actual_entries: Vec<_> = actual.entries_property().collect();
         let marked_actual =
@@ -78,7 +78,7 @@ where
         subject.keys_property().all(|k| k != &self.expected_key)
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &M, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &M, format: &DiffFormat) -> String {
         let expected_key = &self.expected_key;
         let actual_entries: Vec<_> = actual.entries_property().collect();
         let found: HashSet<usize> = actual_entries
@@ -119,7 +119,7 @@ where
         missing.is_empty()
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &M, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &M, format: &DiffFormat) -> String {
         let expected_keys = &self.expected_keys;
         let missing = &self.missing;
         let actual_entries: Vec<_> = actual.entries_property().collect();
@@ -169,7 +169,7 @@ where
         extra.is_empty()
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &M, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &M, format: &DiffFormat) -> String {
         let expected_keys = &self.expected_keys;
         let extra = &self.extra;
         let actual_entries: Vec<_> = actual.entries_property().collect();
@@ -218,7 +218,7 @@ where
         missing.is_empty() && extra.is_empty()
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &M, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &M, format: &DiffFormat) -> String {
         let expected_keys = &self.expected_keys;
         let missing = &self.missing;
         let extra = &self.extra;
@@ -278,7 +278,7 @@ where
         subject.values_property().any(|v| v == &self.expected_value)
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &M, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &M, format: &DiffFormat) -> String {
         let expected_value = &self.expected_value;
         let actual_entries: Vec<_> = actual.entries_property().collect();
         let marked_actual =
@@ -300,7 +300,7 @@ where
         subject.values_property().all(|v| v != &self.expected_value)
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &M, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &M, format: &DiffFormat) -> String {
         let expected_value = &self.expected_value;
         let actual_entries: Vec<_> = actual.entries_property().collect();
         let found: HashSet<usize> = actual_entries
@@ -341,7 +341,7 @@ where
         missing.is_empty()
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &M, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &M, format: &DiffFormat) -> String {
         let expected_values = &self.expected_values;
         let missing = &self.missing;
         let actual_entries: Vec<_> = actual.entries_property().collect();
@@ -391,7 +391,7 @@ where
         extra.is_empty()
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &M, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &M, format: &DiffFormat) -> String {
         let expected_values = &self.expected_values;
         let extra = &self.extra;
         let actual_entries: Vec<_> = actual.entries_property().collect();

--- a/src/number.rs
+++ b/src/number.rs
@@ -45,7 +45,7 @@ where
         subject.is_negative_property()
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_expected = mark_missing_substr("< 0", format);
         format!("expected {expression} is negative\n   but was: {marked_actual}\n  expected: {marked_expected}")
@@ -60,7 +60,7 @@ where
         !subject.is_negative_property()
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_expected = mark_missing_substr(">= 0", format);
         format!("expected {expression} is not negative\n   but was: {marked_actual}\n  expected: {marked_expected}")
@@ -75,7 +75,7 @@ where
         subject.is_positive_property()
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_expected = mark_missing_substr("> 0", format);
         format!("expected {expression} is positive\n   but was: {marked_actual}\n  expected: {marked_expected}")
@@ -90,7 +90,7 @@ where
         !subject.is_positive_property()
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_expected = mark_missing_substr("<= 0", format);
         format!("expected {expression} is not positive\n   but was: {marked_actual}\n  expected: {marked_expected}")
@@ -119,7 +119,7 @@ where
         *subject == <S as AdditiveIdentityProperty>::ADDITIVE_IDENTITY
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_expected = mark_missing(&S::ADDITIVE_IDENTITY, format);
         format!("expected {expression} is zero\n   but was: {marked_actual}\n  expected: {marked_expected}")
@@ -134,7 +134,7 @@ where
         *subject == <S as MultiplicativeIdentityProperty>::MULTIPLICATIVE_IDENTITY
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_expected = mark_missing(&S::MULTIPLICATIVE_IDENTITY, format);
         format!("expected {expression} is one\n   but was: {marked_actual}\n  expected: {marked_expected}")
@@ -163,7 +163,7 @@ where
         subject.is_finite_property()
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_expected = mark_missing_substr("a finite number", format);
         format!("expected {expression} is finite\n   but was: {marked_actual}\n  expected: {marked_expected}")
@@ -178,7 +178,7 @@ where
         subject.is_infinite_property()
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_expected = mark_missing_substr("an infinite number", format);
         format!("expected {expression} is infinite\n   but was: {marked_actual}\n  expected: {marked_expected}")
@@ -207,7 +207,7 @@ where
         !subject.is_nan_property()
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_expected = mark_missing_substr("a number", format);
         format!("expected {expression} is a number\n   but was: {marked_actual}\n  expected: {marked_expected}")
@@ -222,7 +222,7 @@ where
         subject.is_nan_property()
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_expected = mark_missing_substr("NaN", format);
         format!("expected {expression} is not a number (NaN)\n   but was: {marked_actual}\n  expected: {marked_expected}")

--- a/src/option/mod.rs
+++ b/src/option/mod.rs
@@ -56,7 +56,7 @@ where
 
     fn message(
         &self,
-        expression: Expression<'_>,
+        expression: &Expression<'_>,
         actual: &Option<T>,
         format: &DiffFormat,
     ) -> String {
@@ -79,7 +79,7 @@ where
 
     fn message(
         &self,
-        expression: Expression<'_>,
+        expression: &Expression<'_>,
         actual: &Option<T>,
         format: &DiffFormat,
     ) -> String {
@@ -105,7 +105,7 @@ where
 
     fn message(
         &self,
-        expression: Expression<'_>,
+        expression: &Expression<'_>,
         actual: &Option<T>,
         format: &DiffFormat,
     ) -> String {

--- a/src/order/mod.rs
+++ b/src/order/mod.rs
@@ -53,7 +53,7 @@ where
         subject < &self.expected
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_expected = mark_missing(&self.expected, format);
         format!(
@@ -72,7 +72,7 @@ where
         subject <= &self.expected
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_expected = mark_missing(&self.expected, format);
         format!(
@@ -91,7 +91,7 @@ where
         subject > &self.expected
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_expected = mark_missing(&self.expected, format);
         format!(
@@ -110,7 +110,7 @@ where
         subject >= &self.expected
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_expected = mark_missing(&self.expected, format);
         format!(
@@ -129,7 +129,7 @@ where
         subject < &self.expected
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_expected = mark_missing(&self.expected, format);
         format!(
@@ -148,7 +148,7 @@ where
         subject > &self.expected
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_expected = mark_missing(&self.expected, format);
         format!(
@@ -167,7 +167,7 @@ where
         subject >= &self.min && subject <= &self.max
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_start = if actual < &self.min {
             mark_missing(&self.min, format)

--- a/src/panic/mod.rs
+++ b/src/panic/mod.rs
@@ -50,7 +50,7 @@ where
 
     fn message(
         &self,
-        expression: Expression<'_>,
+        expression: &Expression<'_>,
         _actual: &Code<S>,
         format: &DiffFormat,
     ) -> String {
@@ -99,7 +99,7 @@ where
 
     fn message(
         &self,
-        expression: Expression<'_>,
+        expression: &Expression<'_>,
         _actual: &Code<S>,
         format: &DiffFormat,
     ) -> String {

--- a/src/predicate/mod.rs
+++ b/src/predicate/mod.rs
@@ -12,7 +12,7 @@ where
         (self.predicate)(subject)
     }
 
-    fn message(&self, expression: Expression<'_>, _actual: &S, _format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, _actual: &S, _format: &DiffFormat) -> String {
         self.message.clone().unwrap_or_else(|| {
             format!("expected {expression} to satisfy the given predicate, but returned false")
         })

--- a/src/range/mod.rs
+++ b/src/range/mod.rs
@@ -59,7 +59,7 @@ where
         self.expected_range.contains(subject)
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_expected_start = match self.expected_range.start_bound() {
             Bound::Included(start) => {
@@ -112,7 +112,7 @@ where
         !self.expected_range.contains(subject)
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_expected_start = match self.expected_range.start_bound() {
             Bound::Included(start) => format!("< {}", mark_missing(start, format)),

--- a/src/result/mod.rs
+++ b/src/result/mod.rs
@@ -106,7 +106,7 @@ where
 
     fn message(
         &self,
-        expression: Expression<'_>,
+        expression: &Expression<'_>,
         actual: &Result<T, E>,
         format: &DiffFormat,
     ) -> String {
@@ -130,7 +130,7 @@ where
 
     fn message(
         &self,
-        expression: Expression<'_>,
+        expression: &Expression<'_>,
         actual: &Result<T, E>,
         format: &DiffFormat,
     ) -> String {
@@ -155,7 +155,7 @@ where
 
     fn message(
         &self,
-        expression: Expression<'_>,
+        expression: &Expression<'_>,
         actual: &Result<T, E>,
         format: &DiffFormat,
     ) -> String {
@@ -180,7 +180,7 @@ where
 
     fn message(
         &self,
-        expression: Expression<'_>,
+        expression: &Expression<'_>,
         actual: &Result<T, E>,
         format: &DiffFormat,
     ) -> String {

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -119,7 +119,7 @@ where
         subject.as_ref().contains(self.expected)
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected_substr(actual.as_ref(), format);
         let marked_expected = mark_missing_substr(self.expected, format);
         format!(
@@ -137,7 +137,7 @@ where
         subject.as_ref().contains(&self.expected)
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected_substr(actual.as_ref(), format);
         let marked_expected = mark_missing_substr(self.expected.as_ref(), format);
         format!(
@@ -155,7 +155,7 @@ where
         subject.as_ref().contains(self.expected)
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected_substr(actual.as_ref(), format);
         let marked_expected = mark_missing_char(self.expected, format);
         format!(
@@ -173,7 +173,7 @@ where
         subject.as_ref().starts_with(self.expected)
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let expected_char_len = self.expected.chars().count();
         let actual_start = actual
             .as_ref()
@@ -202,7 +202,7 @@ where
         subject.as_ref().starts_with(&self.expected)
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let expected_char_len = self.expected.chars().count();
         let actual_start = actual
             .as_ref()
@@ -231,7 +231,7 @@ where
         subject.as_ref().starts_with(self.expected)
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let actual_first_char = actual.as_ref().chars().take(1).collect::<String>();
         let actual_rest = actual.as_ref().chars().skip(1).collect::<String>();
         let marked_actual_start = mark_unexpected_substr(&actual_first_char, format);
@@ -251,7 +251,7 @@ where
         subject.as_ref().ends_with(self.expected)
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let actual_char_len = actual.as_ref().chars().count();
         let expected_char_len = self.expected.chars().count();
         let split_point = actual_char_len.saturating_sub(expected_char_len);
@@ -282,7 +282,7 @@ where
         subject.as_ref().ends_with(&self.expected)
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let actual_char_len = actual.as_ref().chars().count();
         let expected_char_len = self.expected.chars().count();
         let split_point = actual_char_len.saturating_sub(expected_char_len);
@@ -313,7 +313,7 @@ where
         subject.as_ref().ends_with(self.expected)
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let actual_last_char = actual
             .as_ref()
             .chars()
@@ -375,7 +375,7 @@ where
         subject.as_ref().contains(self.expected)
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_expected = mark_missing(&self.expected, format);
         format!(
@@ -393,7 +393,7 @@ where
         subject.as_ref().contains(self.expected)
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_expected = mark_missing(&self.expected, format);
         format!(
@@ -411,7 +411,7 @@ where
         subject.as_ref().contains(self.expected)
     }
 
-    fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+    fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
         let marked_actual = mark_unexpected(actual, format);
         let marked_expected = mark_missing(&self.expected, format);
         format!(
@@ -449,7 +449,7 @@ mod regex {
                 .is_ok_and(|regex| regex.is_match(subject.as_ref()))
         }
 
-        fn message(&self, expression: Expression<'_>, actual: &S, format: &DiffFormat) -> String {
+        fn message(&self, expression: &Expression<'_>, actual: &S, format: &DiffFormat) -> String {
             let pattern = self.pattern;
             match self.regex.as_ref() {
                 Ok(regex) => {


### PR DESCRIPTION
It might be useful to compose the expression in a `Spec` dynamically. Therefore the implementation of `Expression` is changed to hold a `Cow<'a, str>` instead of a `&'a str`.

BREAKING-CHANGE:
- `Expression` no longer implements `Copy`
- the trait `Expectation` has changed method signature for `message()` which takes a borrowed `Expression` instead of an owned one
- the method `Spec::named()` is no longer const