### PR TITLE
feat: assert each item in a collection or iterator

### DIFF
--- a/src/boolean/tests.rs
+++ b/src/boolean/tests.rs
@@ -25,7 +25,7 @@ fn verify_bool_is_not_equal_to_false_fails() {
         failures,
         &[r"assertion failed: expected my_thing is not equal to false
    but was: false
-  expected: false
+  expected: not false
 "]
     );
 }

--- a/src/equality.rs
+++ b/src/equality.rs
@@ -51,7 +51,7 @@ where
 
     fn message(&self, expression: &Expression<'_>, actual: &S, _format: &DiffFormat) -> String {
         format!(
-            "expected {expression} is not equal to {:?}\n   but was: {actual:?}\n  expected: {:?}",
+            "expected {expression} is not equal to {:?}\n   but was: {actual:?}\n  expected: not {:?}",
             &self.expected, &self.expected
         )
     }

--- a/src/integer/tests.rs
+++ b/src/integer/tests.rs
@@ -499,7 +499,7 @@ mod colored {
             failures,
             &["assertion failed: expected subject is not equal to 42\n   \
                but was: 42\n  \
-              expected: 42\n\
+              expected: not 42\n\
             "]
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,21 @@
 //!     .contains_only([1, 3, 5, 7, 9, 11, 13, 17, 19, 23, 29, 31, 37, 43]);
 //! ```
 //!
+//! ## Asserting each item of a collection or iterator
+//!
+//! ```
+//! use asserting::prelude::*;
+//!
+//! let numbers = [2, 4, 6, 8, 10];
+//!
+//! assert_that!(numbers).each_item(|e|
+//!     e.is_greater_than(1)
+//!         .is_at_most(10)
+//! );
+//! ```
+//!
+//! For more details see [`Spec::each_item()`].
+//!
 //! ## Soft assertions
 //!
 //! ```should_panic
@@ -582,6 +597,7 @@
 //! [`Expectation`]: spec::Expectation
 //! [`LengthProperty`]: properties::LengthProperty
 //! [`Spec`]: spec::Spec
+//! [`Spec::each_item()`]: spec::Spec::each_item
 //! [`Spec::expecting()`]: spec::Spec::expecting
 //! [`Spec::satisfies()`]: spec::Spec::satisfies
 //! [`Spec::soft_panic()`]: spec::Spec::soft_panic

--- a/src/spec/mod.rs
+++ b/src/spec/mod.rs
@@ -1037,6 +1037,47 @@ impl<S> Spec<'_, S, CollectFailures> {
 }
 
 impl<'a, I, R> Spec<'a, I, R> {
+    /// Iterates over the items of a collection or iterator and executes the
+    /// given assertions for each of those items.
+    ///
+    /// It iterates over all items of the collection or iterator and collects
+    /// the failure messages for those items where the assertion fails. In other
+    /// words, it does not stop iterating when the assertion for one item fails.
+    ///
+    /// The failure messages contain the position of the item within the
+    /// collection or iterator. The position is 1 based. So a failure message
+    /// for the first item contains "1. item", the second "2. item", etc.
+    ///
+    /// # Example
+    ///
+    /// The following assertion:
+    ///
+    /// ```should_panic
+    /// use asserting::prelude::*;
+    ///
+    /// let numbers = [2, 4, 6, 8, 10];
+    ///
+    /// assert_that!(numbers).each_item(|e|
+    ///     e.is_greater_than(2)
+    ///         .is_at_most(7)
+    /// );
+    /// ```
+    ///
+    /// will print:
+    ///
+    /// ```console
+    /// assertion failed: expected numbers 1. item is greater than 2
+    ///    but was: 2
+    ///   expected: > 2
+    ///
+    /// assertion failed: expected numbers 4. item is at most 7
+    ///    but was: 8
+    ///   expected: <= 7
+    ///
+    /// assertion failed: expected numbers 5. item is at most 7
+    ///    but was: 10
+    ///   expected: <= 7
+    /// ```
     #[allow(clippy::return_self_not_must_use)]
     pub fn each_item<T, A, B>(mut self, assert: A) -> Spec<'a, (), R>
     where

--- a/src/spec/mod.rs
+++ b/src/spec/mod.rs
@@ -1032,7 +1032,7 @@ impl<'a, I, R> Spec<'a, I, R> {
         for item in self.subject {
             let element_spec = Spec {
                 subject: item,
-                expression: Some(Expression("iterator-item")),
+                expression: Some(Expression("iterator-item".into())),
                 description: None,
                 location: self.location,
                 failures: vec![],

--- a/src/spec/mod.rs
+++ b/src/spec/mod.rs
@@ -1060,6 +1060,11 @@ impl<'a, I, R> Spec<'a, I, R> {
             let failures = assert(element_spec).failures;
             self.failures.extend(failures);
         }
+        if !self.failures.is_empty()
+            && any::type_name_of_val(&self.failing_strategy) == any::type_name::<PanicOnFail>()
+        {
+            PanicOnFail.do_fail_with(&self.failures);
+        }
         Spec {
             subject: (),
             expression: self.expression,

--- a/src/spec/tests.rs
+++ b/src/spec/tests.rs
@@ -251,6 +251,17 @@ fn assert_each_item_of_a_borrowed_iterator() {
 }
 
 #[test]
+#[should_panic = "assertion failed: expected numbers 2. item is not equal to 4\n   but was: 4\n  expected: not 4\n"]
+fn assert_each_item_of_an_iterator_panics_if_one_assertion_fails() {
+    let subject = [2, 4, 6, 8, 10];
+
+    assert_that(subject)
+        .named("numbers")
+        .is_not_empty()
+        .each_item(|e| e.is_not_equal_to(4));
+}
+
+#[test]
 fn verify_assert_each_item_of_an_iterator_fails() {
     let subject = [2, 4, 6, 8, 10];
 

--- a/src/spec/tests.rs
+++ b/src/spec/tests.rs
@@ -232,6 +232,52 @@ fn soft_assertions_panic_once_with_multiple_failure_messages() {
         .soft_panic();
 }
 
+#[test]
+fn assert_each_item_of_an_iterator() {
+    let subject = [2, 4, 6, 8, 10];
+
+    assert_that(subject)
+        .is_not_empty()
+        .each_item(|e| e.is_positive().is_at_most(20));
+}
+
+#[test]
+fn assert_each_item_of_a_borrowed_iterator() {
+    let subject = [2, 4, 6, 8, 10];
+
+    assert_that(&subject)
+        .is_not_empty()
+        .each_item(|e| e.is_positive().is_at_most(&20));
+}
+
+#[test]
+fn verify_assert_each_item_of_an_iterator_fails() {
+    let subject = [2, 4, 6, 8, 10];
+
+    let failures = verify_that(&subject)
+        .named("numbers")
+        .each_item(|e| e.is_greater_than(&2).is_at_most(&7))
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected iterator-item is greater than 2
+   but was: 2
+  expected: > 2
+",
+            r"assertion failed: expected iterator-item is at most 7
+   but was: 8
+  expected: <= 7
+",
+            r"assertion failed: expected iterator-item is at most 7
+   but was: 10
+  expected: <= 7
+",
+        ]
+    );
+}
+
 #[cfg(feature = "colored")]
 mod colored {
     use crate::prelude::*;

--- a/src/spec/tests.rs
+++ b/src/spec/tests.rs
@@ -262,15 +262,15 @@ fn verify_assert_each_item_of_an_iterator_fails() {
     assert_eq!(
         failures,
         &[
-            r"assertion failed: expected iterator-item is greater than 2
+            r"assertion failed: expected numbers 1. item is greater than 2
    but was: 2
   expected: > 2
 ",
-            r"assertion failed: expected iterator-item is at most 7
+            r"assertion failed: expected numbers 4. item is at most 7
    but was: 8
   expected: <= 7
 ",
-            r"assertion failed: expected iterator-item is at most 7
+            r"assertion failed: expected numbers 5. item is at most 7
    but was: 10
   expected: <= 7
 ",

--- a/src/string/tests.rs
+++ b/src/string/tests.rs
@@ -1088,7 +1088,7 @@ mod colored {
             failures,
             &["assertion failed: expected subject is not equal to \"aute aliquip culpa blandit\"\n   \
                but was: \"aute aliquip culpa blandit\"\n  \
-              expected: \"aute aliquip culpa blandit\"\n\
+              expected: not \"aute aliquip culpa blandit\"\n\
             "]
         );
     }


### PR DESCRIPTION
Provide the possibility to assert each element of a collection or iterator.

Added the method `Spec::each_item()` that enables users to write assertions that are executed for each item in a collection or iterator.