### PR TITLE
refactor: change signature of methods of `AssertCodePanics` trait so that …

### DIFF
--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -1048,19 +1048,19 @@ pub trait AssertIsSorted {
 /// does not panic.
 #[cfg(feature = "panic")]
 #[cfg_attr(docsrs, doc(cfg(feature = "panic")))]
-pub trait AssertCodePanics {
+pub trait AssertCodePanics<'a, R> {
     /// Verifies that the actual code under test does not panic.
     #[track_caller]
-    fn does_not_panic(self) -> Self;
+    fn does_not_panic(self) -> Spec<'a, (), R>;
 
     /// Verifies that the actual code under test panics with any message.
     #[track_caller]
-    fn panics(self) -> Self;
+    fn panics(self) -> Spec<'a, (), R>;
 
     /// Verifies that the actual code under test panics with the given
     /// message.
     #[track_caller]
-    fn panics_with_message(self, message: impl Into<String>) -> Self;
+    fn panics_with_message(self, message: impl Into<String>) -> Spec<'a, (), R>;
 }
 
 /// Assertions for the keys of a map.

--- a/src/panic/mod.rs
+++ b/src/panic/mod.rs
@@ -10,21 +10,22 @@ use crate::std::panic;
 const ONLY_ONE_EXPECTATION: &str = "only one expectation allowed when asserting closures!";
 const UNKNOWN_PANIC_MESSAGE: &str = "<unknown panic message>";
 
-impl<S, R> AssertCodePanics for Spec<'_, Code<S>, R>
+impl<'a, S, R> AssertCodePanics<'a, R> for Spec<'a, Code<S>, R>
 where
     S: FnOnce(),
     R: FailingStrategy,
 {
-    fn does_not_panic(self) -> Self {
-        self.expecting(DoesNotPanic::default())
+    fn does_not_panic(self) -> Spec<'a, (), R> {
+        self.expecting(DoesNotPanic::default()).mapping(|_| ())
     }
 
-    fn panics(self) -> Self {
-        self.expecting(DoesPanic::default())
+    fn panics(self) -> Spec<'a, (), R> {
+        self.expecting(DoesPanic::default()).mapping(|_| ())
     }
 
-    fn panics_with_message(self, message: impl Into<String>) -> Self {
+    fn panics_with_message(self, message: impl Into<String>) -> Spec<'a, (), R> {
         self.expecting(DoesPanic::with_message(message))
+            .mapping(|_| ())
     }
 }
 

--- a/src/panic/tests.rs
+++ b/src/panic/tests.rs
@@ -124,45 +124,6 @@ fn verify_code_does_panic_with_message_fails_because_unexpected_panic_message() 
     );
 }
 
-#[test]
-fn verify_can_not_perform_two_does_not_panic_assertions_on_same_code_subject() {
-    let failures = verify_that_code(|| {
-        assert_that(2 + 3).is_equal_to(5);
-    })
-    .named("my_closure")
-    .does_not_panic()
-    .does_not_panic()
-    .display_failures();
-
-    assert_eq!(
-        failures,
-        &[
-            r"assertion failed: error in test assertion: only one expectation allowed when asserting closures!
-"
-        ]
-    );
-}
-
-#[test]
-fn verify_can_not_perform_two_panics_assertions_on_same_code_subject() {
-    let failures = verify_that_code(|| {
-        #[allow(unconditional_panic)]
-        assert_that(2 / 0).is_equal_to(0);
-    })
-    .named("my_closure")
-    .panics()
-    .panics()
-    .display_failures();
-
-    assert_eq!(
-        failures,
-        &[
-            r"assertion failed: error in test assertion: only one expectation allowed when asserting closures!
-"
-        ]
-    );
-}
-
 #[cfg(feature = "colored")]
 mod colored {
     use crate::prelude::*;


### PR DESCRIPTION
…code assertions can not be chained

Assertions whether a closure panics or does not panic can not be chained. A closure can only be asserted once. Currently it is possible to write chained assertions for a closure, but the second assertion panics at runtime.

Instead of a runtime error, a compile time error should be issued, when a chained assertion is written for a closure.

The signature of the methods of the extension trait `AssertCodePanics` have been changed to return a `Spec` with a subject of the unit type. It is now longer possible to compile chained assertions for panicking code on closures.