### PR TITLE
fix!: remove implementation of `Default` for `DoesPanic`

### DIFF
--- a/src/expectations.rs
+++ b/src/expectations.rs
@@ -592,7 +592,6 @@ mod panic {
     use std::any::Any;
 
     #[must_use]
-    #[derive(Default)]
     pub struct DoesPanic {
         pub expected_message: Option<String>,
         pub actual_message: Option<String>,
@@ -600,7 +599,10 @@ mod panic {
 
     impl DoesPanic {
         pub fn with_any_message() -> Self {
-            Self::default()
+            Self {
+                expected_message: None,
+                actual_message: None,
+            }
         }
 
         pub fn with_message(message: impl Into<String>) -> Self {

--- a/src/panic/mod.rs
+++ b/src/panic/mod.rs
@@ -20,7 +20,7 @@ where
     }
 
     fn panics(self) -> Self {
-        self.expecting(DoesPanic::default())
+        self.expecting(DoesPanic::with_any_message())
     }
 
     fn panics_with_message(self, message: impl Into<String>) -> Self {

--- a/src/panic/mod.rs
+++ b/src/panic/mod.rs
@@ -20,7 +20,8 @@ where
     }
 
     fn panics(self) -> Spec<'a, (), R> {
-        self.expecting(DoesPanic::with_any_message()).mapping(|_| ())
+        self.expecting(DoesPanic::with_any_message())
+            .mapping(|_| ())
     }
 
     fn panics_with_message(self, message: impl Into<String>) -> Spec<'a, (), R> {


### PR DESCRIPTION
Currently the expectation `DoesPanic` implements the `Default` trait. This supports no sensible usecase and it is not clear what a default `DoesPanic` expectation is supposed to do.

Remove the implementation of the `Default` trait for the `DoesPanic` expectation.