### PR TITLE
fix!: delete the trait `RangeLike`

### DIFF
--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -355,15 +355,6 @@ pub trait AssertOrder<E> {
     fn is_between(self, min: E, max: E) -> Self;
 }
 
-/// Common interface for supported range-like types.
-pub trait RangeLike<T> {
-    /// Returns true if this range contains the given value.
-    fn contains_value<E>(&self, value: &E) -> bool
-    where
-        T: PartialOrd<E>,
-        E: PartialOrd<T>;
-}
-
 /// Assert whether a value is within an expected range.
 ///
 /// The expected range can be any of range.


### PR DESCRIPTION
The trait `RangeLike` is not used and not needed. This trait was defined for experiments with asserting ranges. It is an oversight that it has not been deleted when it becomes clear, that it will not be used.

Deleted the trait `RangeLike`.

BREAKING-CHANGE:
The trait `RangeLike` has never beend used in any released version of `asserting`.