### PR TITLE
fix: assertions for `Option` are not available for borrowed `&Option`

### DIFF
--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -1433,6 +1433,40 @@ pub trait AssertOptionValue<'a, T, R> {
     fn some(self) -> Spec<'a, T, R>;
 }
 
+/// Assert the borrowed option value by mapping the subject.
+///
+/// If the option is none, the assertion fails.
+///
+/// # Examples
+///
+/// ```
+/// use asserting::prelude::*;
+///
+/// let subject: Option<Vec<usize>> = Some(vec![1, 2, 3]);
+/// assert_that!(&subject).some().contains_exactly(&[1, 2, 3]);
+///
+/// let subject: Option<&str> = Some("ullamco cupiditat diam hendrerit");
+/// assert_that!(&subject).some().is_not_empty();
+/// ```
+pub trait AssertBorrowedOptionValue<'a, T, R> {
+    /// Maps the subject to the option's value if it has some. Otherwise, this
+    /// assertion fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use asserting::prelude::*;
+    ///
+    /// let subject: Option<Vec<usize>> = Some(vec![1, 2, 3]);
+    /// assert_that!(&subject).some().contains_exactly(&[1, 2, 3]);
+    ///
+    /// let subject: Option<&str> = Some("ullamco cupiditat diam hendrerit");
+    /// assert_that!(&subject).some().is_not_empty();
+    /// ```
+    #[track_caller]
+    fn some(self) -> Spec<'a, &'a T, R>;
+}
+
 /// Assert whether a subject of the `Result` type holds some value or an error.
 ///
 /// # Examples

--- a/src/option/tests.rs
+++ b/src/option/tests.rs
@@ -35,42 +35,42 @@ fn option_of_string_is_some() {
 #[test]
 fn option_of_custom_struct_is_none() {
     #[derive(Debug)]
-    struct MyStruct;
+    struct Foo;
 
-    let subject: Option<MyStruct> = None;
+    let subject: Option<Foo> = None;
 
     assert_that(subject).is_none();
 }
 
 #[test]
-fn option_of_string_has_some_str_value() {
-    let subject = Some("non tempor ea delenit".to_string());
+fn verify_option_of_custom_struct_is_none_fails() {
+    #[derive(Debug)]
+    struct Foo;
 
-    assert_that(subject).has_value("non tempor ea delenit");
+    let subject: Option<Foo> = Some(Foo);
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .is_none()
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[r"assertion failed: expected my_thing is None
+   but was: Some(Foo)
+  expected: None
+"]
+    );
 }
 
 #[test]
-fn option_of_str_has_some_str_value() {
-    let subject = Some("facilisi cupiditat elitr facilisis");
+fn option_of_custom_struct_is_some() {
+    #[derive(Debug)]
+    struct Foo;
 
-    assert_that(subject).has_value("facilisi cupiditat elitr facilisis");
-}
+    let subject: Option<Foo> = Some(Foo);
 
-#[test]
-fn option_of_str_has_some_string_value() {
-    let subject = Some("invidunt commodi eros vel");
-
-    assert_that(subject).has_value("invidunt commodi eros vel".to_string());
-}
-
-#[test]
-fn option_of_custom_struct_has_value() {
-    #[derive(Debug, PartialEq)]
-    struct MyStruct;
-
-    let subject = Some(MyStruct);
-
-    assert_that(subject).has_value(MyStruct);
+    assert_that(subject).is_some();
 }
 
 #[test]
@@ -95,13 +95,23 @@ fn verify_option_of_custom_struct_is_some_fails() {
 }
 
 #[test]
-fn verify_option_of_custom_struct_is_none_fails() {
+fn borrowed_option_of_custom_struct_is_none() {
     #[derive(Debug)]
-    struct MyStruct;
+    struct Foo;
 
-    let subject: Option<MyStruct> = Some(MyStruct);
+    let subject: Option<Foo> = None;
 
-    let failures = verify_that(subject)
+    assert_that(&subject).is_none();
+}
+
+#[test]
+fn verify_borrowed_option_of_custom_struct_is_none_fails() {
+    #[derive(Debug)]
+    struct Foo;
+
+    let subject: Option<Foo> = Some(Foo);
+
+    let failures = verify_that(&subject)
         .named("my_thing")
         .is_none()
         .display_failures();
@@ -109,10 +119,68 @@ fn verify_option_of_custom_struct_is_none_fails() {
     assert_eq!(
         failures,
         &[r"assertion failed: expected my_thing is None
-   but was: Some(MyStruct)
+   but was: Some(Foo)
   expected: None
 "]
     );
+}
+
+#[test]
+fn borrowed_option_of_custom_struct_is_some() {
+    #[derive(Debug)]
+    struct Foo;
+
+    let subject: Option<Foo> = Some(Foo);
+
+    assert_that(&subject).is_some();
+}
+
+#[test]
+fn verify_borrowed_option_of_custom_struct_is_some_fails() {
+    #[derive(Debug)]
+    struct MyStruct;
+
+    let subject: Option<MyStruct> = None;
+
+    let failures = verify_that(&subject)
+        .named("my_thing")
+        .is_some()
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[r"assertion failed: expected my_thing is Some(_)
+   but was: None
+  expected: Some(_)
+"]
+    );
+}
+
+#[test]
+fn option_of_borrowed_custom_struct_is_none() {
+    #[derive(Debug)]
+    struct Foo;
+
+    let subject: Option<&Foo> = None;
+
+    assert_that(&subject).is_none();
+}
+
+#[test]
+fn option_of_borrowed_custom_struct_is_some() {
+    #[derive(Debug)]
+    struct Foo;
+
+    let subject: Option<&Foo> = Some(&Foo);
+
+    assert_that(&subject).is_some();
+}
+
+#[test]
+fn option_of_string_has_some_str_value() {
+    let subject = Some("non tempor ea delenit".to_string());
+
+    assert_that(subject).has_value("non tempor ea delenit");
 }
 
 #[test]
@@ -136,6 +204,92 @@ fn verify_option_of_string_has_some_value_fails() {
 }
 
 #[test]
+fn option_of_str_has_some_str_value() {
+    let subject = Some("facilisi cupiditat elitr facilisis");
+
+    assert_that(subject).has_value("facilisi cupiditat elitr facilisis");
+}
+
+#[test]
+fn option_of_str_has_some_string_value() {
+    let subject = Some("invidunt commodi eros vel");
+
+    assert_that(subject).has_value("invidunt commodi eros vel".to_string());
+}
+
+#[test]
+fn option_of_custom_struct_has_value() {
+    #[derive(Debug, PartialEq)]
+    struct Foo;
+
+    let subject = Some(Foo);
+
+    assert_that(subject).has_value(Foo);
+}
+
+#[test]
+fn verify_option_of_custom_struct_has_value_fails() {
+    #[derive(Debug, PartialEq)]
+    struct Foo;
+
+    let subject: Option<Foo> = None;
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .has_value(Foo)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[r"assertion failed: expected my_thing is some containing Foo
+   but was: None
+  expected: Some(Foo)
+"]
+    );
+}
+
+#[test]
+fn borrowed_option_of_custom_struct_has_value() {
+    #[derive(Debug, PartialEq)]
+    struct Foo;
+
+    let subject = Some(Foo);
+
+    assert_that(&subject).has_value(Foo);
+}
+
+#[test]
+fn verify_borrowed_option_of_custom_struct_has_value_fails() {
+    #[derive(Debug, PartialEq)]
+    struct Foo;
+
+    let subject: Option<Foo> = None;
+
+    let failures = verify_that(&subject)
+        .named("my_thing")
+        .has_value(Foo)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[r"assertion failed: expected my_thing is some containing Foo
+   but was: None
+  expected: Some(Foo)
+"]
+    );
+}
+
+#[test]
+fn option_of_borrowed_custom_struct_has_value() {
+    #[derive(Debug, PartialEq)]
+    struct Foo;
+
+    let subject = Some(&Foo);
+
+    assert_that(subject).has_value(&Foo);
+}
+
+#[test]
 fn map_option_with_some_value_to_its_value() {
     let subject = Some(vec![1, 2, 3]);
 
@@ -149,6 +303,24 @@ fn map_option_with_none_to_its_value() {
 
     assert_that_code(|| {
         assert_that(subject).some().is_empty();
+    })
+    .panics_with_message("assertion failed: expected the subject to be `Some(_)`, but was `None`");
+}
+
+#[test]
+fn map_borrowed_option_with_some_value_to_its_value() {
+    let subject = Some(vec![1, 2, 3]);
+
+    assert_that(&subject).some().is_not_empty();
+}
+
+#[cfg(feature = "panic")]
+#[test]
+fn map_borrowed_option_with_none_to_its_value() {
+    let subject: Option<Vec<usize>> = None;
+
+    assert_that_code(|| {
+        assert_that(&subject).some().is_empty();
     })
     .panics_with_message("assertion failed: expected the subject to be `Some(_)`, but was `None`");
 }


### PR DESCRIPTION
Currently a borrowed `Option` can not be asserted. Assertions like:

```rust
assert_that!(&Some(42)).is_some();
assert_that!(&Some([1, 2, 3])).some().contains(&2);
```

are expected to work but result in compile errors.

Implemented assertions for `Option` for borrowed `&Option` as well.
