### PR TITLE
fix: assertions for `Result` are not available for borrowed `&Result`

### DIFF
--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -1399,7 +1399,7 @@ pub trait AssertOption {
     fn is_none(self) -> Self;
 }
 
-/// Assert the option value by mapping the subject.
+/// Assert the value of an option by mapping the subject.
 ///
 /// If the option is none, the assertion fails.
 ///
@@ -1433,7 +1433,7 @@ pub trait AssertOptionValue<'a, T, R> {
     fn some(self) -> Spec<'a, T, R>;
 }
 
-/// Assert the borrowed option value by mapping the subject.
+/// Assert the value of a borrowed option by mapping the subject.
 ///
 /// If the option is none, the assertion fails.
 ///
@@ -1508,7 +1508,7 @@ pub trait AssertResult {
     fn is_err(self) -> Self;
 }
 
-/// Assert the result value or error by mapping the subject.
+/// Assert the ok-value or error of a result by mapping the subject.
 ///
 /// # Examples
 ///
@@ -1551,6 +1551,51 @@ pub trait AssertResultValue<'a, T, E, R> {
     /// ```
     #[track_caller]
     fn err(self) -> Spec<'a, E, R>;
+}
+
+/// Assert the ok-value or error of a borrowed result by mapping the subject.
+///
+/// # Examples
+///
+/// ```
+/// use asserting::prelude::*;
+///
+/// let subject: Result<Vec<usize>, String> = Ok(vec![1, 2, 3]);
+/// assert_that!(&subject).ok().is_not_empty();
+///
+/// let subject: Result<u64, String> = Err("te anim adipisici mollit".to_string());
+/// assert_that!(&subject).err().is_equal_to("te anim adipisici mollit");
+/// ```
+pub trait AssertBorrowedResultValue<'a, T, E, R> {
+    /// Maps the subject to the result's ok value.
+    ///
+    /// If the result is an error, this method panics.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use asserting::prelude::*;
+    ///
+    /// let subject: Result<Vec<usize>, String> = Ok(vec![1, 2, 3]);
+    /// assert_that!(&subject).ok().contains_exactly(&[1, 2, 3]);
+    /// ```
+    #[track_caller]
+    fn ok(self) -> Spec<'a, &'a T, R>;
+
+    /// Maps the subject to the result's err value.
+    ///
+    /// If the result is an ok value, this method panics.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use asserting::prelude::*;
+    ///
+    /// let subject: Result<u64, String> = Err("te anim adipisici mollit".to_string());
+    /// assert_that!(&subject).err().is_equal_to("te anim adipisici mollit");
+    /// ```
+    #[track_caller]
+    fn err(self) -> Spec<'a, &'a E, R>;
 }
 
 /// Assert that a subject of some container type holds a value that is equal to

--- a/src/result/mod.rs
+++ b/src/result/mod.rs
@@ -1,7 +1,8 @@
 //! Implementation of assertions for `Result` values.
 
 use crate::assertions::{
-    AssertHasError, AssertHasErrorMessage, AssertHasValue, AssertResult, AssertResultValue,
+    AssertBorrowedResultValue, AssertHasError, AssertHasErrorMessage, AssertHasValue, AssertResult,
+    AssertResultValue,
 };
 use crate::colored::{mark_missing, mark_unexpected};
 use crate::expectations::{HasError, HasValue, IsEqualTo, IsErr, IsOk};
@@ -13,6 +14,21 @@ use crate::std::{
 };
 
 impl<T, E, R> AssertResult for Spec<'_, Result<T, E>, R>
+where
+    T: Debug,
+    E: Debug,
+    R: FailingStrategy,
+{
+    fn is_ok(self) -> Self {
+        self.expecting(IsOk)
+    }
+
+    fn is_err(self) -> Self {
+        self.expecting(IsErr)
+    }
+}
+
+impl<T, E, R> AssertResult for Spec<'_, &Result<T, E>, R>
 where
     T: Debug,
     E: Debug,
@@ -51,7 +67,43 @@ where
     }
 }
 
+impl<'a, T, E, R> AssertBorrowedResultValue<'a, T, E, R> for Spec<'a, &'a Result<T, E>, R>
+where
+    T: Debug,
+    E: Debug,
+{
+    fn ok(self) -> Spec<'a, &'a T, R> {
+        self.mapping(|subject| match subject {
+            Ok(value) => value,
+            Err(error) => {
+                panic!("assertion failed: expected the subject to be `Ok(_)`, but was `Err({error:?})`")
+            },
+        })
+    }
+
+    fn err(self) -> Spec<'a, &'a E, R> {
+        self.mapping(|subject| match subject {
+            Ok(value) => {
+                panic!("assertion failed: expected the subject to be `Err(_)`, but was `Ok({value:?})`")
+            },
+            Err(error) => error,
+        })
+    }
+}
+
 impl<T, E, X, R> AssertHasValue<X> for Spec<'_, Result<T, E>, R>
+where
+    T: PartialEq<X> + Debug,
+    E: Debug,
+    X: Debug,
+    R: FailingStrategy,
+{
+    fn has_value(self, expected: X) -> Self {
+        self.expecting(HasValue { expected })
+    }
+}
+
+impl<T, E, X, R> AssertHasValue<X> for Spec<'_, &Result<T, E>, R>
 where
     T: PartialEq<X> + Debug,
     E: Debug,
@@ -75,7 +127,39 @@ where
     }
 }
 
+impl<T, E, X, R> AssertHasError<X> for Spec<'_, &Result<T, E>, R>
+where
+    T: Debug,
+    E: PartialEq<X> + Debug,
+    X: Debug,
+    R: FailingStrategy,
+{
+    fn has_error(self, expected: X) -> Self {
+        self.expecting(HasError { expected })
+    }
+}
+
 impl<'a, T, E, X, R> AssertHasErrorMessage<'a, X, R> for Spec<'a, Result<T, E>, R>
+where
+    T: Debug,
+    E: Display,
+    X: Debug,
+    String: PartialEq<X>,
+    R: FailingStrategy,
+{
+    fn has_error_message(self, expected: X) -> Spec<'a, String, R> {
+        self.mapping(|result| match result {
+            Ok(value) => panic!(
+                r"assertion failed: expected the subject to be `Err(_)` with message {expected:?}, but was `Ok({value:?})`"
+            ),
+            Err(error) => {
+                error.to_string()
+            },
+        }).expecting(IsEqualTo {expected})
+    }
+}
+
+impl<'a, T, E, X, R> AssertHasErrorMessage<'a, X, R> for Spec<'a, &Result<T, E>, R>
 where
     T: Debug,
     E: Display,
@@ -143,6 +227,54 @@ where
     }
 }
 
+impl<T, E> Expectation<&Result<T, E>> for IsOk
+where
+    T: Debug,
+    E: Debug,
+{
+    fn test(&mut self, subject: &&Result<T, E>) -> bool {
+        subject.is_ok()
+    }
+
+    fn message(
+        &self,
+        expression: &Expression<'_>,
+        actual: &&Result<T, E>,
+        format: &DiffFormat,
+    ) -> String {
+        let expected = Ok::<_, Unknown>(Unknown);
+        let marked_actual = mark_unexpected(actual, format);
+        let marked_expected = mark_missing(&expected, format);
+        format!(
+            "expected {expression} is {expected:?}\n   but was: {marked_actual}\n  expected: {marked_expected}"
+        )
+    }
+}
+
+impl<T, E> Expectation<&Result<T, E>> for IsErr
+where
+    T: Debug,
+    E: Debug,
+{
+    fn test(&mut self, subject: &&Result<T, E>) -> bool {
+        subject.is_err()
+    }
+
+    fn message(
+        &self,
+        expression: &Expression<'_>,
+        actual: &&Result<T, E>,
+        format: &DiffFormat,
+    ) -> String {
+        let expected = Err::<Unknown, Unknown>(Unknown);
+        let marked_actual = mark_unexpected(actual, format);
+        let marked_expected = mark_missing(&expected, format);
+        format!(
+            "expected {expression} is {expected:?}\n   but was: {marked_actual}\n  expected: {marked_expected}"
+        )
+    }
+}
+
 impl<T, E, X> Expectation<Result<T, E>> for HasValue<X>
 where
     T: PartialEq<X> + Debug,
@@ -168,6 +300,31 @@ where
     }
 }
 
+impl<T, E, X> Expectation<&Result<T, E>> for HasValue<X>
+where
+    T: PartialEq<X> + Debug,
+    E: Debug,
+    X: Debug,
+{
+    fn test(&mut self, subject: &&Result<T, E>) -> bool {
+        subject.as_ref().is_ok_and(|value| value == &self.expected)
+    }
+
+    fn message(
+        &self,
+        expression: &Expression<'_>,
+        actual: &&Result<T, E>,
+        format: &DiffFormat,
+    ) -> String {
+        let expected = &self.expected;
+        let marked_actual = mark_unexpected(actual, format);
+        let marked_expected = mark_missing(&Ok::<_, E>(expected), format);
+        format!(
+            "expected {expression} is ok containing {expected:?}\n   but was: {marked_actual}\n  expected: {marked_expected}"
+        )
+    }
+}
+
 impl<T, E, X> Expectation<Result<T, E>> for HasError<X>
 where
     T: Debug,
@@ -182,6 +339,31 @@ where
         &self,
         expression: &Expression<'_>,
         actual: &Result<T, E>,
+        format: &DiffFormat,
+    ) -> String {
+        let expected = &self.expected;
+        let marked_actual = mark_unexpected(actual, format);
+        let marked_expected = mark_missing(&Err::<T, _>(expected), format);
+        format!(
+            "expected {expression} is error containing {expected:?}\n   but was: {marked_actual}\n  expected: {marked_expected}"
+        )
+    }
+}
+
+impl<T, E, X> Expectation<&Result<T, E>> for HasError<X>
+where
+    T: Debug,
+    E: PartialEq<X> + Debug,
+    X: Debug,
+{
+    fn test(&mut self, subject: &&Result<T, E>) -> bool {
+        subject.as_ref().is_err_and(|err| err == &self.expected)
+    }
+
+    fn message(
+        &self,
+        expression: &Expression<'_>,
+        actual: &&Result<T, E>,
         format: &DiffFormat,
     ) -> String {
         let expected = &self.expected;

--- a/src/result/tests.rs
+++ b/src/result/tests.rs
@@ -15,6 +15,19 @@ fn result_of_i32_is_ok() {
 }
 
 #[test]
+fn result_of_custom_types_is_ok() {
+    #[derive(Debug)]
+    struct MyValue;
+
+    #[derive(Debug)]
+    struct MyError;
+
+    let subject: Result<MyValue, MyError> = Ok(MyValue);
+
+    assert_that(subject).is_ok();
+}
+
+#[test]
 fn result_of_custom_types_is_err() {
     #[derive(Debug)]
     struct MyValue;
@@ -158,6 +171,162 @@ fn verify_result_of_custom_types_has_error_fails() {
 }
 
 #[test]
+fn borrowed_result_of_custom_types_is_ok() {
+    #[derive(Debug)]
+    struct MyValue;
+
+    #[derive(Debug)]
+    struct MyError;
+
+    let subject: Result<MyValue, MyError> = Ok(MyValue);
+
+    assert_that(&subject).is_ok();
+}
+
+#[test]
+fn borrowed_result_of_custom_types_is_err() {
+    #[derive(Debug)]
+    struct MyValue;
+
+    #[derive(Debug)]
+    struct MyError;
+
+    let subject: Result<MyValue, MyError> = Err(MyError);
+
+    assert_that(&subject).is_err();
+}
+
+#[test]
+fn verify_borrowed_result_of_custom_types_is_ok_fails() {
+    #[derive(Debug)]
+    struct MyValue;
+
+    #[allow(dead_code)]
+    #[derive(Debug)]
+    struct MyError(String);
+
+    let subject: Result<MyValue, MyError> = Err(MyError("aute nam ad amet".to_string()));
+
+    let failures = verify_that(&subject)
+        .named("my_thing")
+        .is_ok()
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[r#"assertion failed: expected my_thing is Ok(_)
+   but was: Err(MyError("aute nam ad amet"))
+  expected: Ok(_)
+"#]
+    );
+}
+
+#[test]
+fn verify_borrowed_result_of_custom_types_is_err_fails() {
+    #[allow(dead_code)]
+    #[derive(Debug)]
+    struct MyValue(i32);
+
+    #[derive(Debug)]
+    struct MyError;
+
+    let subject: Result<MyValue, MyError> = Ok(MyValue(42));
+
+    let failures = verify_that(&subject)
+        .named("my_thing")
+        .is_err()
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[r"assertion failed: expected my_thing is Err(_)
+   but was: Ok(MyValue(42))
+  expected: Err(_)
+"]
+    );
+}
+
+#[test]
+fn borrowed_result_of_custom_types_has_value() {
+    #[derive(Debug, PartialEq)]
+    struct MyValue(i32);
+
+    #[derive(Debug)]
+    struct MyError;
+
+    let subject: Result<MyValue, MyError> = Ok(MyValue(42));
+
+    assert_that(&subject).has_value(MyValue(42));
+}
+
+#[test]
+fn borrowed_result_of_custom_types_has_error() {
+    #[derive(Debug)]
+    struct MyValue;
+
+    #[derive(Debug, PartialEq)]
+    struct MyError(String);
+
+    let subject: Result<MyValue, MyError> = Err(MyError("to complicated!".to_string()));
+
+    assert_that(&subject).has_error(MyError("to complicated!".to_string()));
+}
+
+#[test]
+fn verify_borrowed_result_of_custom_types_has_value_fails() {
+    #[derive(Debug, PartialEq)]
+    struct MyValue(String);
+
+    #[allow(dead_code)]
+    #[derive(Debug)]
+    struct MyError(String);
+
+    let subject: Result<MyValue, MyError> = Err(MyError("amet esse rebum feugait".to_string()));
+
+    let failures = verify_that(&subject)
+        .named("my_thing")
+        .has_value(MyValue("sea non obcaecat nostrud".to_string()))
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r#"assertion failed: expected my_thing is ok containing MyValue("sea non obcaecat nostrud")
+   but was: Err(MyError("amet esse rebum feugait"))
+  expected: Ok(MyValue("sea non obcaecat nostrud"))
+"#
+        ]
+    );
+}
+
+#[test]
+fn verify_borrowed_result_of_custom_types_has_error_fails() {
+    #[allow(dead_code)]
+    #[derive(Debug)]
+    struct MyValue(u32);
+
+    #[derive(Debug, PartialEq)]
+    struct MyError(i32);
+
+    let subject: Result<MyValue, MyError> = Ok(MyValue(42));
+
+    let failures = verify_that(&subject)
+        .named("my_thing")
+        .has_error(MyError(-1))
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing is error containing MyError(-1)
+   but was: Ok(MyValue(42))
+  expected: Err(MyError(-1))
+"
+        ]
+    );
+}
+
+#[test]
 fn map_result_with_ok_value_to_its_ok_value() {
     let subject: Result<Vec<u64>, String> = Ok(vec![]);
 
@@ -196,6 +365,44 @@ fn map_result_with_ok_value_to_its_err_value() {
 }
 
 #[test]
+fn map_borrowed_result_with_ok_value_to_its_ok_value() {
+    let subject: Result<Vec<u64>, String> = Ok(vec![]);
+
+    assert_that(&subject).ok().is_empty();
+}
+
+#[cfg(feature = "panic")]
+#[test]
+fn map_borrowed_result_with_err_value_to_its_ok_value() {
+    let subject: Result<Vec<usize>, String> = Err("nam nihil iure liber".to_string());
+
+    assert_that_code(|| {
+        assert_that(&subject).ok().is_not_empty();
+    })
+        .panics_with_message("assertion failed: expected the subject to be `Ok(_)`, but was `Err(\"nam nihil iure liber\")`");
+}
+
+#[test]
+fn map_borrowed_result_with_err_value_to_its_err_value() {
+    let subject: Result<(), String> = Err("tempor aliquip amet exerci".to_string());
+
+    assert_that(&subject).err().is_not_empty();
+}
+
+#[cfg(feature = "panic")]
+#[test]
+fn map_borrowed_result_with_ok_value_to_its_err_value() {
+    let subject: Result<Vec<usize>, String> = Ok(vec![1, 2, 3]);
+
+    assert_that_code(|| {
+        assert_that(&subject).err().is_not_empty();
+    })
+    .panics_with_message(
+        "assertion failed: expected the subject to be `Err(_)`, but was `Ok([1, 2, 3])`",
+    );
+}
+
+#[test]
 fn result_error_has_message_for_an_anyhow_error() {
     let subject: Result<(), anyhow::Error> = Err(anyhow!("id hendrerit clita kasd"));
 
@@ -226,6 +433,42 @@ fn verify_result_error_has_message_for_ok_value() {
 
     assert_that_code(|| {
         assert_that(subject).has_error_message("vulputate voluptate sanctus quod");
+    }).panics_with_message(
+        r#"assertion failed: expected the subject to be `Err(_)` with message "vulputate voluptate sanctus quod", but was `Ok(())`"#,
+    );
+}
+
+#[test]
+fn borrowed_result_error_has_message_for_an_anyhow_error() {
+    let subject: Result<(), anyhow::Error> = Err(anyhow!("id hendrerit clita kasd"));
+
+    assert_that(&subject).has_error_message("id hendrerit clita kasd");
+}
+
+#[test]
+fn borrowed_result_error_has_message_for_custom_error_type() {
+    #[derive(Debug)]
+    struct OpaqueError(String);
+
+    impl Display for OpaqueError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(&self.0)
+        }
+    }
+
+    let subject: Result<(), OpaqueError> =
+        Err(OpaqueError("soluta dolor vero takimata".to_string()));
+
+    assert_that(&subject).has_error_message("soluta dolor vero takimata");
+}
+
+#[cfg(feature = "panic")]
+#[test]
+fn verify_borrowed_result_error_has_message_for_ok_value() {
+    let subject: Result<(), anyhow::Error> = Ok(());
+
+    assert_that_code(|| {
+        assert_that(&subject).has_error_message("vulputate voluptate sanctus quod");
     }).panics_with_message(
         r#"assertion failed: expected the subject to be `Err(_)` with message "vulputate voluptate sanctus quod", but was `Ok(())`"#,
     );


### PR DESCRIPTION
Borrowed `&Result` can not be asserted. Assertions like

```rust
assert_that!(&Ok(vec![1, 2, 3])).is_ok();
assert_that!(&Err("severe failure".to_string())).is_err();
assert_that!(&Ok(vec![1, ,2, 3])).has_value(&vec![1, 2, 3]);
assert_that!(&Ok(vec![1, 2, 3])).ok().contains_exactly(&[1, ,2 ,3]);
assert_that!(&Err("severe failure".to_string())).has_error_message("severe failure");
```

are expected to work, but result in compile errors.

Implemented assertions for `Result` for borrowed `&Result` as well.