### PR TITLE
chore: use the `fakeenv` crate for testing environment variable specific functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ sdiff = { version = "0.1", optional = true }
 
 [dev-dependencies]
 anyhow = "1"
+fakeenv = { version = "0.1", default-features = false, features = ["fake"] }
 proptest = "1"
-serial_test = "3"
 time = { version = "0.3", default-features = false, features = ["macros"] }
 version-sync = "0.9"
 

--- a/examples/fixture/mod.rs
+++ b/examples/fixture/mod.rs
@@ -4,6 +4,7 @@ mod dummy_extern_uses {
     use anyhow as _;
     #[cfg(feature = "bigdecimal")]
     use bigdecimal as _;
+    use fakeenv as _;
     #[cfg(feature = "float-cmp")]
     use float_cmp as _;
     use hashbrown as _;
@@ -18,7 +19,6 @@ mod dummy_extern_uses {
     use rust_decimal as _;
     #[cfg(feature = "colored")]
     use sdiff as _;
-    use serial_test as _;
     use time as _;
     use version_sync as _;
 }

--- a/src/colored/mod.rs
+++ b/src/colored/mod.rs
@@ -699,7 +699,7 @@ mod with_colored_feature {
     /// Returns true if the environment variable `NO_COLOR` is set.
     #[cfg(feature = "std")]
     fn is_no_color_env_var_set() -> bool {
-        use crate::std::env;
+        use crate::env;
 
         match env::var(ENV_VAR_NO_COLOR) {
             Ok(value) => !value.is_empty(),
@@ -718,7 +718,7 @@ mod with_colored_feature {
     #[must_use]
     #[inline]
     pub fn configured_diff_format_impl() -> DiffFormat {
-        use crate::std::env;
+        use crate::env;
 
         match env::var(ENV_VAR_HIGHLIGHT_DIFFS) {
             Ok(value) => {

--- a/src/colored/tests.rs
+++ b/src/colored/tests.rs
@@ -90,13 +90,11 @@ mod with_colored_but_not_std_feature {
 mod with_colored_and_std_features {
     use super::*;
     use crate::colored::with_colored_feature::ENV_VAR_HIGHLIGHT_DIFFS;
-    use crate::std::env;
+    use crate::env;
     use hashbrown::HashMap;
     use proptest::prelude::*;
-    use serial_test::serial;
 
     #[test]
-    #[serial]
     fn get_configured_diff_format_when_env_var_not_set() {
         env::remove_var(ENV_VAR_HIGHLIGHT_DIFFS);
 
@@ -106,7 +104,6 @@ mod with_colored_and_std_features {
     }
 
     #[test]
-    #[serial]
     fn get_configured_diff_format_when_env_var_not_set_and_no_color_env_var_set() {
         env::remove_var(ENV_VAR_HIGHLIGHT_DIFFS);
         env::set_var("NO_COLOR", "1");
@@ -119,7 +116,6 @@ mod with_colored_and_std_features {
     }
 
     #[test]
-    #[serial]
     fn get_configured_diff_format_when_env_var_set_to_unknown_mode() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "not-valid");
 
@@ -129,7 +125,6 @@ mod with_colored_and_std_features {
     }
 
     #[test]
-    #[serial]
     fn get_configured_diff_format_when_env_var_set_to_bold_mode() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "bold");
 
@@ -139,7 +134,6 @@ mod with_colored_and_std_features {
     }
 
     #[test]
-    #[serial]
     fn get_configured_diff_format_when_env_var_set_to_bold_mode_and_no_color_env_var_set() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "bold");
         env::set_var("NO_COLOR", "1");
@@ -152,7 +146,6 @@ mod with_colored_and_std_features {
     }
 
     #[test]
-    #[serial]
     fn get_configured_diff_format_when_env_var_set_to_red_green_mode() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "red-green");
 
@@ -162,7 +155,6 @@ mod with_colored_and_std_features {
     }
 
     #[test]
-    #[serial]
     fn get_configured_diff_format_when_env_var_set_to_red_green_mode_and_no_color_env_var_set() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "red-green");
         env::set_var("NO_COLOR", "1");
@@ -175,7 +167,6 @@ mod with_colored_and_std_features {
     }
 
     #[test]
-    #[serial]
     fn get_configured_diff_format_when_env_var_set_to_red_blue_mode() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "red-blue");
 
@@ -185,7 +176,6 @@ mod with_colored_and_std_features {
     }
 
     #[test]
-    #[serial]
     fn get_configured_diff_format_when_env_var_set_to_red_blue_mode_and_no_color_env_var_set() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "red-blue");
         env::set_var("NO_COLOR", "1");
@@ -198,7 +188,6 @@ mod with_colored_and_std_features {
     }
 
     #[test]
-    #[serial]
     fn get_configured_diff_format_when_env_var_set_to_red_yellow_mode() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "red-yellow");
 
@@ -208,7 +197,6 @@ mod with_colored_and_std_features {
     }
 
     #[test]
-    #[serial]
     fn get_configured_diff_format_when_env_var_set_to_red_yellow_mode_and_no_color_env_var_set() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "red-yellow");
         env::set_var("NO_COLOR", "1");
@@ -221,7 +209,6 @@ mod with_colored_and_std_features {
     }
 
     #[test]
-    #[serial]
     fn get_configured_diff_format_when_env_var_set_to_off() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "off");
 
@@ -232,11 +219,10 @@ mod with_colored_and_std_features {
 
     proptest! {
         #[test]
-        #[serial]
         fn setting_env_var_to_bold_is_case_insensitive(
             mode in "[bB][oO][lL][dD]"
         ) {
-            env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, mode);
+            env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, &mode);
 
             let diff_format = configured_diff_format();
 
@@ -244,11 +230,10 @@ mod with_colored_and_std_features {
         }
 
         #[test]
-        #[serial]
         fn setting_env_var_to_red_blue_is_case_insensitive(
             mode in "[rR][eE][dD]-[bB][lL][uU][eE]"
         ) {
-            env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, mode);
+            env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, &mode);
 
             let diff_format = configured_diff_format();
 
@@ -256,11 +241,10 @@ mod with_colored_and_std_features {
         }
 
         #[test]
-        #[serial]
         fn setting_env_var_to_red_yellow_is_case_insensitive(
             mode in "[rR][eE][dD]-[yY][eE][lL][lL][oO][wW]"
         ) {
-            env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, mode);
+            env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, &mode);
 
             let diff_format = configured_diff_format();
 
@@ -268,11 +252,10 @@ mod with_colored_and_std_features {
         }
 
         #[test]
-        #[serial]
         fn setting_env_var_to_off_is_case_insensitive(
             mode in "[oO][fF][fF]"
         ) {
-            env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, mode);
+            env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, &mode);
 
             let diff_format = configured_diff_format();
 
@@ -281,7 +264,6 @@ mod with_colored_and_std_features {
     }
 
     #[test]
-    #[serial]
     fn assert_that_sets_the_diff_format_to_red_green() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "red-green");
 
@@ -291,7 +273,6 @@ mod with_colored_and_std_features {
     }
 
     #[test]
-    #[serial]
     fn verify_that_sets_the_diff_format_to_no_highlighting() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "red-green");
 
@@ -301,7 +282,6 @@ mod with_colored_and_std_features {
     }
 
     #[test]
-    #[serial]
     fn assert_that_code_sets_the_diff_format_to_red_green() {
         env::set_var(ENV_VAR_HIGHLIGHT_DIFFS, "red-green");
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,0 +1,36 @@
+//! Fakeable `env` module for tests.
+//!
+//! inspired by
+//! [Testing code that uses environment variables](https://www.reddit.com/r/rust/comments/1jd8sxg/testing_code_that_uses_environment_variables/)
+//! - post on Reddit
+
+pub use std::env::VarError;
+
+#[cfg(not(test))]
+pub use std::env::var;
+
+#[cfg(test)]
+pub use fake_env::*;
+
+#[cfg(test)]
+mod fake_env {
+    use fakeenv::EnvStore;
+    use std::cell::RefCell;
+    use std::env::VarError;
+
+    thread_local! {
+        static ENV_STORE: RefCell<EnvStore> = RefCell::new(EnvStore::fake());
+    }
+
+    pub fn var(key: &str) -> Result<String, VarError> {
+        ENV_STORE.with(|env| env.borrow().var(key))
+    }
+
+    pub fn set_var(key: &str, value: &str) {
+        ENV_STORE.with(|env| env.borrow_mut().set_var(key, value));
+    }
+
+    pub fn remove_var(key: &str) {
+        ENV_STORE.with(|env| env.borrow_mut().remove_var(key));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -678,6 +678,8 @@ mod c_string;
 mod char;
 mod char_count;
 mod collection;
+#[cfg(feature = "std")]
+mod env;
 mod equality;
 mod error;
 mod float;
@@ -713,8 +715,8 @@ type TestCodeSnippetsInReadme = ();
 // Rust issue [#95513](https://github.com/rust-lang/rust/issues/95513) is fixed
 #[cfg(test)]
 mod dummy_extern_uses {
+    use fakeenv as _;
     use proptest as _;
-    use serial_test as _;
     use time as _;
     use version_sync as _;
 }

--- a/tests/version_numbers.rs
+++ b/tests/version_numbers.rs
@@ -8,6 +8,7 @@ mod dummy_extern_uses {
     use asserting as _;
     #[cfg(feature = "bigdecimal")]
     use bigdecimal as _;
+    use fakeenv as _;
     #[cfg(feature = "float-cmp")]
     use float_cmp as _;
     use hashbrown as _;
@@ -22,7 +23,6 @@ mod dummy_extern_uses {
     use rust_decimal as _;
     #[cfg(feature = "colored")]
     use sdiff as _;
-    use serial_test as _;
     use time as _;
 }
 


### PR DESCRIPTION
Testing code that makes decisions based on the value of environment variables faces two problems:

1. The tests can not run in parallel as setting or removing an environment variable in one testcase may influence other testcases
2. As we know from Rust edition 2024 the functions `std::env::set_var` and `std::env::remove_var` are unsafe on some operating systems

For the first problem we used the `serial_test` crate to mark all tests that shall not run in parallel.

Using a fake "environment", that mimics the related functions from the `std::env` module, for testing solves both problems. The crate `serial_test` is no longer needed as a dependency.

Refactored tests in `colored::tests` module to use a fake environment and removed the `serial_test` dependency.