### PR TITLE
chore: optimize ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,12 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - uses: Swatinem/rust-cache@v2
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: --all-features
+      - uses: Swatinem/rust-cache@v2
 
   fmt:
     name: Rustfmt check
@@ -74,6 +74,7 @@ jobs:
           toolchain: nightly
           components: rustfmt
       - run: cargo +nightly fmt --check --all
+      - uses: Swatinem/rust-cache@v2
 
   test:
     name: Run tests
@@ -98,12 +99,12 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           override: true
-      - uses: Swatinem/rust-cache@v2
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all-features --no-fail-fast
+      - uses: Swatinem/rust-cache@v2
   
   no-std:
     name: Test no-std support
@@ -117,12 +118,12 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - uses: Swatinem/rust-cache@v2
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --no-default-features --features "colored, float-cmp, num-bigint, rust-decimal, bigdecimal"
+      - uses: Swatinem/rust-cache@v2
 
   msrv:
     name: Build with MSRV
@@ -159,9 +160,9 @@ jobs:
         with:
           toolchain: nightly
           override: true
-      - uses: Swatinem/rust-cache@v2
       - name: Run cargo doc
         uses: actions-rs/cargo@v1
         with:
           command: doc
           args: --all-features --no-deps
+      - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,18 +33,6 @@ jobs:
     steps:
       - run: exit 0
   
-  # Basic checks that should run shorter than the full tests 
-  basic:
-    name: basic checks
-    runs-on: ubuntu-latest
-    needs:
-      - fmt
-      - clippy
-      - msrv
-      - doc
-    steps:
-      - run: exit 0
-  
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
@@ -80,7 +68,11 @@ jobs:
   test-all-featues:
     name: Run tests for all features
     runs-on: ${{ matrix.os }}
-    needs: basic
+    needs:
+      - fmt
+      - clippy
+      - msrv
+      - doc
     strategy:
       fail-fast: false
       matrix:
@@ -110,7 +102,11 @@ jobs:
   test-default-features:
     name: Test with default features
     runs-on: ubuntu-latest
-    needs: basic
+    needs:
+      - fmt
+      - clippy
+      - msrv
+      - doc
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -128,7 +124,11 @@ jobs:
   test-no-std:
     name: Test no-std support
     runs-on: ubuntu-latest
-    needs: basic
+    needs:
+      - fmt
+      - clippy
+      - msrv
+      - doc
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
       - clippy
       - msrv
       - doc
-      - test-no-std
+      - test-all-features
       - test-default-features
-      - test-all-featues
+      - test-no-std
     steps:
       - run: exit 0
   
@@ -65,7 +65,7 @@ jobs:
       - run: cargo +nightly fmt --check --all
       - uses: Swatinem/rust-cache@v2
 
-  test-all-featues:
+  test-all-features:
     name: Run tests for all features
     runs-on: ${{ matrix.os }}
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,32 @@ permissions:
   contents: read
 
 jobs:
+  # Depends on all actions that are required for a "successful" CI run.
+  tests-pass:
+    name: all checks successful
+    runs-on: ubuntu-latest
+    needs:
+      - fmt
+      - clippy
+      - msrv
+      - doc
+      - no-std
+      - test
+    steps:
+      - run: exit 0
+  
+  # Basic checks that should run shorter than the full tests 
+  basic:
+    name: basic checks
+    runs-on: ubuntu-latest
+    needs:
+      - fmt
+      - clippy
+      - msrv
+      - doc
+    steps:
+      - run: exit 0
+  
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
@@ -52,6 +78,7 @@ jobs:
   test:
     name: Run tests
     runs-on: ${{ matrix.os }}
+    needs: basic
     strategy:
       fail-fast: false
       matrix:
@@ -81,6 +108,7 @@ jobs:
   no-std:
     name: Test no-std support
     runs-on: ubuntu-latest
+    needs: basic
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,9 @@ jobs:
       - clippy
       - msrv
       - doc
-      - no-std
-      - test
+      - test-no-std
+      - test-default-features
+      - test-all-featues
     steps:
       - run: exit 0
   
@@ -76,8 +77,8 @@ jobs:
       - run: cargo +nightly fmt --check --all
       - uses: Swatinem/rust-cache@v2
 
-  test:
-    name: Run tests
+  test-all-featues:
+    name: Run tests for all features
     runs-on: ${{ matrix.os }}
     needs: basic
     strategy:
@@ -106,7 +107,25 @@ jobs:
           args: --all-features --no-fail-fast
       - uses: Swatinem/rust-cache@v2
   
-  no-std:
+  test-default-features:
+    name: Test with default features
+    runs-on: ubuntu-latest
+    needs: basic
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+      - uses: Swatinem/rust-cache@v2
+  
+  test-no-std:
     name: Test no-std support
     runs-on: ubuntu-latest
     needs: basic

--- a/.ide-settings/jetbrains/runConfigurations/Clippy default-features.run.xml
+++ b/.ide-settings/jetbrains/runConfigurations/Clippy default-features.run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Clippy default-features" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="clippy --all-targets" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="false" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="false" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="NO" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.ide-settings/jetbrains/runConfigurations/Clippy no-std.run.xml
+++ b/.ide-settings/jetbrains/runConfigurations/Clippy no-std.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Clippy no-std" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
-    <option name="command" value="clippy --all-targets --no-default-features --features &quot;colored, float-cmp&quot;" />
+    <option name="command" value="clippy --all-targets --no-default-features --features &quot;colored, float-cmp, num-bigint, bigdecimal, rust-decimal&quot;" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
     <option name="emulateTerminal" value="false" />

--- a/.ide-settings/jetbrains/runConfigurations/Test default-features.run.xml
+++ b/.ide-settings/jetbrains/runConfigurations/Test default-features.run.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Test default-features" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="test" />
+    <option name="command" value="test" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="false" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="false" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="NO" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.ide-settings/jetbrains/runConfigurations/Test lib default-features.run.xml
+++ b/.ide-settings/jetbrains/runConfigurations/Test lib default-features.run.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Test lib default-features" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="test" />
+    <option name="command" value="test --lib" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="false" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="false" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="NO" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.ide-settings/jetbrains/runConfigurations/Test no-std.run.xml
+++ b/.ide-settings/jetbrains/runConfigurations/Test no-std.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Test no-std" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
     <option name="buildProfileId" value="test" />
-    <option name="command" value="test --no-default-features --features &quot;colored, float-cmp, num-bigint&quot;" />
+    <option name="command" value="test --no-default-features --features &quot;colored, float-cmp, num-bigint, bigdecimal, rust-decimal&quot;" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
     <option name="emulateTerminal" value="false" />

--- a/justfile
+++ b/justfile
@@ -8,9 +8,11 @@ alias cc := code-coverage
 alias d := doc
 alias l := lint
 alias la := lint-all-features
+alias ld := lint-default
 alias ln := lint-no-std
 alias t := test
 alias ta := test-all-features
+alias td := test-default
 alias tn := test-no-std
 
 # list recipies
@@ -29,11 +31,16 @@ check:
 lint:
     just lint-all-features
     just lint-no-std
+    just lint-default
     just lint-no-features
 
 # linting code using Clippy with all features enabled
 lint-all-features:
     cargo clippy --all-targets --all-features
+
+# linting code using Clippy with default features enabled
+lint-default:
+    cargo clippy --all-targets
 
 # linting code using Clippy for no-std environment
 lint-no-std:
@@ -47,11 +54,16 @@ lint-no-features:
 test:
     just test-all-features
     just test-no-std
+    just test-default
     just test-no-features
 
 # run tests for all features
 test-all-features:
     cargo test --all-features
+
+# run tests for default features
+test-default:
+    cargo test
 
 # run tests for no-std environment
 test-no-std:

--- a/src/env.rs
+++ b/src/env.rs
@@ -19,7 +19,12 @@ mod fake_env {
     use std::env::VarError;
 
     thread_local! {
-        static ENV_STORE: RefCell<EnvStore> = RefCell::new(EnvStore::fake());
+        static ENV_STORE: RefCell<EnvStore> = RefCell::new({
+            let env = EnvStore::fake();
+            env.remove_var("ASSERTING_HIGHLIGHT_DIFFS");
+            env.remove_var("NO_COLOR");
+            env
+        });
     }
 
     pub fn var(key: &str) -> Result<String, VarError> {


### PR DESCRIPTION
The CI workflow - both the local workflow using `just` and the GitHub workflow - do not run clippy and tests with default features. Further the GitHub workflow does not play well with branch protection.

* Added step to justfile as well as GitHub workflow that runs the tests with default features.
* Added step to "summerize" workflow results for branch protection
* Optimized CI GitHub workflow to run shorter steps before running the tests