### PR TITLE
feat: "does not..." assertions for string

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,27 +260,32 @@ for `bool`.
 
 for strings of type `String` and `str`:
 
-| assertion                   | description                                                                    |
-|-----------------------------|--------------------------------------------------------------------------------|
-| is_empty                    | verify that a string is empty                                                  |                                                 
-| is_not_empty                | verify that a string is not empty                                              |
-| has_length                  | verify that a string has exactly the expected length                           |                                                 
-| has_length_in_range         | verify that a string has a length that is in the expected range                |
-| has_length_less_than        | verify that a string has a length less than the expected length                |
-| has_length_greater_than     | verify that a string has a length greater than the expected length             |
-| has_at_most_length          | verify that a string has a length less than or equal to the expected length    |
-| has_at_least_length         | verify that a string has a length greater than or equal to the expected length |
-| has_char_count              | verify that a string contains exactly the expected number of characters        |                                                 
-| has_char_count_in_range     | verify that a string contains a number of characters in the expected range     |
-| has_char_count_less_than    | verify that a string contains less than the expected number of characters      |
-| has_char_count_greater_than | verify that a string contains more than the expected number of characters      |
-| has_at_most_char_count      | verify that a string contains at most the expected number of characters        |
-| has_at_least_char_count     | verify that a string contains at least the expected number of characters       |
-| contains                    | verify that a string contains the expected substring or character              |
-| starts_with                 | verify that a string starts with the expected substring or character           |
-| ends_with                   | verify that a string ends with the expected substring or character             |
-| contains_any_of             | verify that a string contains any character from a collection of `char`s       |
-| matches                     | verify that a string matches the given regex (requires `regex` feature)        |                                                 
+| assertion                   | description                                                                      |
+|-----------------------------|----------------------------------------------------------------------------------|
+| is_empty                    | verify that a string is empty                                                    |                                                 
+| is_not_empty                | verify that a string is not empty                                                |
+| has_length                  | verify that a string has exactly the expected length                             |                                                 
+| has_length_in_range         | verify that a string has a length that is in the expected range                  |
+| has_length_less_than        | verify that a string has a length less than the expected length                  |
+| has_length_greater_than     | verify that a string has a length greater than the expected length               |
+| has_at_most_length          | verify that a string has a length less than or equal to the expected length      |
+| has_at_least_length         | verify that a string has a length greater than or equal to the expected length   |
+| has_char_count              | verify that a string contains exactly the expected number of characters          |                                                 
+| has_char_count_in_range     | verify that a string contains a number of characters in the expected range       |
+| has_char_count_less_than    | verify that a string contains less than the expected number of characters        |
+| has_char_count_greater_than | verify that a string contains more than the expected number of characters        |
+| has_at_most_char_count      | verify that a string contains at most the expected number of characters          |
+| has_at_least_char_count     | verify that a string contains at least the expected number of characters         |
+| contains                    | verify that a string contains the expected substring or character                |
+| does_not_contain            | verify that a string does not contain the expected substring or character        |
+| starts_with                 | verify that a string starts with the expected substring or character             |
+| does_not_start_with         | verify that a string does not start with the expected substring or character     |
+| ends_with                   | verify that a string ends with the expected substring or character               |
+| does_not_end_with           | verify that a string does not end with the expected substring or character       |
+| contains_any_of             | verify that a string contains any character from a collection of `char`s         |
+| does_not_contain_any_of     | verify that a string does not contain any character from a collection of `char`s |
+| matches                     | verify that a string matches the given regex (requires `regex` feature)          |                                                 
+| does_not_match              | verify that a string does not match the given regex (requires `regex` feature)   |                                                 
 
 for strings of type `CString` and `CStr`:
 

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -2234,6 +2234,13 @@ pub trait AssertErrorHasSource<'a, R> {
 /// assert_that!(subject).starts_with('d');
 /// assert_that!(subject).ends_with("t eum");
 /// assert_that!(subject).ends_with('m');
+///
+/// assert_that!(subject).does_not_contain("pat");
+/// assert_that!(subject).does_not_contain('k');
+/// assert_that!(subject).does_not_start_with("omi");
+/// assert_that!(subject).does_not_start_with('o');
+/// assert_that!(subject).does_not_end_with("meum");
+/// assert_that!(subject).does_not_end_with('u');
 /// ```
 pub trait AssertStringPattern<E> {
     /// Verifies that a string contains a substring or character.
@@ -2251,6 +2258,21 @@ pub trait AssertStringPattern<E> {
     #[track_caller]
     fn contains(self, pattern: E) -> Self;
 
+    /// Verifies that a string does not contain a substring or character.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use asserting::prelude::*;
+    ///
+    /// let subject = "consequat nihil sanctus commodo";
+    ///
+    /// assert_that!(subject).does_not_contain("nixil");
+    /// assert_that!(subject).does_not_contain('v');
+    /// ```
+    #[track_caller]
+    fn does_not_contain(self, pattern: E) -> Self;
+
     /// Verifies that a string starts with a substring or character.
     ///
     /// # Examples
@@ -2266,6 +2288,21 @@ pub trait AssertStringPattern<E> {
     #[track_caller]
     fn starts_with(self, pattern: E) -> Self;
 
+    /// Verifies that a string does not start with a substring or character.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use asserting::prelude::*;
+    ///
+    /// let subject = "ex nulla nostrud proident";
+    ///
+    /// assert_that!(subject).does_not_start_with("nulla");
+    /// assert_that!(subject).does_not_start_with('v');
+    /// ```
+    #[track_caller]
+    fn does_not_start_with(self, pattern: E) -> Self;
+
     /// Verifies that a string ends with a substring or character.
     ///
     /// # Examples
@@ -2280,6 +2317,19 @@ pub trait AssertStringPattern<E> {
     /// ```
     #[track_caller]
     fn ends_with(self, pattern: E) -> Self;
+
+    /// Verifies that a string does not end with a substring or character.
+    ///
+    /// ```
+    /// use asserting::prelude::*;
+    ///
+    /// let subject = "sunt lorem at duo";
+    ///
+    /// assert_that!(subject).does_not_end_with("duos");
+    /// assert_that!(subject).does_not_end_with('v');
+    /// ```
+    #[track_caller]
+    fn does_not_end_with(self, pattern: E) -> Self;
 }
 
 /// Assert that a string contains any char from a collection of chars.
@@ -2294,9 +2344,14 @@ pub trait AssertStringPattern<E> {
 /// assert_that!(subject).contains_any_of(['a', 'b', 'm', 'z']);
 /// assert_that!(subject).contains_any_of(&['a', 'b', 'm', 'z']);
 /// assert_that!(subject).contains_any_of(&['a', 'b', 'm', 'z'][..]);
+///
+/// assert_that!(subject).does_not_contain_any_of(['x', 'y', 'z']);
+/// assert_that!(subject).does_not_contain_any_of(&['x', 'y', 'z']);
+/// assert_that!(subject).does_not_contain_any_of(&['x', 'y', 'z'][..]);
 /// ```
 pub trait AssertStringContainsAnyOf<E> {
-    /// Verifies that a string contains any char from a collection of chars.
+    /// Verifies that a string contains any char from a collection of
+    /// characters.
     ///
     /// # Examples
     ///
@@ -2310,7 +2365,24 @@ pub trait AssertStringContainsAnyOf<E> {
     /// assert_that!(subject).contains_any_of(&['a', 'b',  'm', 'z'][..]);
     /// ```
     #[track_caller]
-    fn contains_any_of(self, pattern: E) -> Self;
+    fn contains_any_of(self, expected: E) -> Self;
+
+    /// Verifies that a string does not contain any char from a collection of
+    /// characters.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use asserting::prelude::*;
+    ///
+    /// let subject = "sunt lorem at duo";
+    ///
+    /// assert_that!(subject).does_not_contain_any_of(['v', 'w', 'x']);
+    /// assert_that!(subject).does_not_contain_any_of(&['v', 'w', 'x']);
+    /// assert_that!(subject).does_not_contain_any_of(&['v', 'w', 'x'][..]);
+    /// ```
+    #[track_caller]
+    fn does_not_contain_any_of(self, expected: E) -> Self;
 }
 
 /// Assert that a string matches a regex pattern.
@@ -2325,12 +2397,13 @@ pub trait AssertStringContainsAnyOf<E> {
 /// use asserting::prelude::*;
 ///
 /// assert_that("tation odio placerat in").matches(r"\b\w{8}\b");
+/// assert_that("tation odio placerat in").does_not_match(r"^[A-Z0-9 ]+$");
 /// # }
 /// ```
 #[cfg(feature = "regex")]
 #[cfg_attr(docsrs, doc(cfg(feature = "regex")))]
 pub trait AssertStringMatches {
-    /// Verifies that a string matches the given regex pattern.
+    /// Verifies that a string matches a regex pattern.
     ///
     /// # Example
     ///
@@ -2344,8 +2417,35 @@ pub trait AssertStringMatches {
     /// assert_that("tation odio placerat in").matches(r"\b\w{8}\b");
     /// # }
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the given regex pattern is invalid or exceeds the
+    /// size limit.
     #[track_caller]
     fn matches(self, regex_pattern: &str) -> Self;
+
+    /// Verifies that a string does not match a regex pattern.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # #[cfg(not(feature = "regex"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "regex")]
+    /// # fn main() {
+    /// use asserting::prelude::*;
+    ///
+    /// assert_that("tation odio placerat in").does_not_match(r"^[A-Z0-9 ]+$");
+    /// # }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the given regex pattern is invalid or exceeds the
+    /// size limit.
+    #[track_caller]
+    fn does_not_match(self, regex_pattern: &str) -> Self;
 }
 
 /// Assert that an iterator or collection contains the expected value.

--- a/src/char/mod.rs
+++ b/src/char/mod.rs
@@ -1,5 +1,5 @@
 use crate::assertions::AssertChar;
-use crate::colored::{mark_missing_substr, mark_unexpected_char};
+use crate::colored::{mark_missing_string, mark_unexpected_char};
 use crate::expectations::{
     IsAlphabetic, IsAlphanumeric, IsAscii, IsControlChar, IsDigit, IsLowerCase, IsUpperCase,
     IsWhitespace,
@@ -100,7 +100,7 @@ impl Expectation<char> for IsLowerCase {
             ("", actual.to_lowercase().to_string())
         };
         let marked_actual = mark_unexpected_char(*actual, format);
-        let marked_expected = mark_missing_substr(&expected, format);
+        let marked_expected = mark_missing_string(&expected, format);
         format!("expected {expression} to be {not}lowercase\n   but was: {marked_actual}\n  expected: {marked_expected}")
     }
 }
@@ -141,7 +141,7 @@ impl Expectation<char> for IsUpperCase {
             ("", actual.to_uppercase().to_string())
         };
         let marked_actual = mark_unexpected_char(*actual, format);
-        let marked_expected = mark_missing_substr(&expected, format);
+        let marked_expected = mark_missing_string(&expected, format);
         format!("expected {expression} to be {not}uppercase\n   but was: {marked_actual}\n  expected: {marked_expected}")
     }
 }

--- a/src/colored/mod.rs
+++ b/src/colored/mod.rs
@@ -54,19 +54,20 @@ pub use with_colored_feature::{
 use crate::spec::{DiffFormat, Highlight};
 use crate::std::fmt::Debug;
 use crate::std::format;
-use crate::std::string::String;
+use crate::std::string::{String, ToString};
+use crate::std::vec::Vec;
 use hashbrown::HashSet;
 #[cfg(feature = "colored")]
 use with_colored_feature::{
     configured_diff_format_impl, mark_diff_impl, mark_missing_char_impl, mark_missing_impl,
-    mark_missing_substr_impl, mark_unexpected_char_impl, mark_unexpected_impl,
-    mark_unexpected_substr_impl,
+    mark_missing_string_impl, mark_unexpected_char_impl, mark_unexpected_impl,
+    mark_unexpected_string_impl,
 };
 #[cfg(not(feature = "colored"))]
 use without_colored_feature::{
     configured_diff_format_impl, mark_diff_impl, mark_missing_char_impl, mark_missing_impl,
-    mark_missing_substr_impl, mark_unexpected_char_impl, mark_unexpected_impl,
-    mark_unexpected_substr_impl,
+    mark_missing_string_impl, mark_unexpected_char_impl, mark_unexpected_impl,
+    mark_unexpected_string_impl,
 };
 
 const NO_HIGHLIGHT: Highlight = Highlight { start: "", end: "" };
@@ -189,13 +190,13 @@ pub fn configured_diff_format() -> DiffFormat {
 /// ```
 pub fn mark_diff<S, E>(actual: &S, expected: &E, format: &DiffFormat) -> (String, String)
 where
-    S: Debug,
-    E: Debug,
+    S: Debug + ?Sized,
+    E: Debug + ?Sized,
 {
     mark_diff_impl(actual, expected, format)
 }
 
-/// Highlight the given value as "unexpected value" using the color for
+/// Highlights the given value as "unexpected value" using the color for
 /// unexpected values or bold as specified by the given [`DiffFormat`].
 pub fn mark_unexpected<T>(value: &T, format: &DiffFormat) -> String
 where
@@ -204,7 +205,7 @@ where
     mark_unexpected_impl(value, format)
 }
 
-/// Highlight the given value as "missing value" using the color for
+/// Highlights the given value as "missing value" using the color for
 /// "missing values" as specified by the given [`DiffFormat`].
 pub fn mark_missing<T>(value: &T, format: &DiffFormat) -> String
 where
@@ -213,27 +214,27 @@ where
     mark_missing_impl(value, format)
 }
 
-/// Highlight the given string as "unexpected value" using the color for
+/// Highlights the given string as "unexpected value" using the color for
 /// unexpected values or bold as specified by the given [`DiffFormat`].
 ///
 /// When using this function in comparison to [`mark_unexpected`], the returned
 /// string does not contain quotes at the start and end of the string as they
 /// appear in the debug formatted string returned by [`mark_unexpected`].
-pub fn mark_unexpected_substr(substr: &str, format: &DiffFormat) -> String {
-    mark_unexpected_substr_impl(substr, format)
+pub fn mark_unexpected_string(string: &str, format: &DiffFormat) -> String {
+    mark_unexpected_string_impl(string, format)
 }
 
-/// Highlight the given string as "missing value" using the color for
+/// Highlights the given string as "missing value" using the color for
 /// missing values as specified by the given [`DiffFormat`].
 ///
 /// When using this function in comparison to [`mark_missing`], the returned
 /// string does not contain quotes at the start and end of the string as they
 /// appear in the debug formatted string returned by [`mark_missing`].
-pub fn mark_missing_substr(substr: &str, format: &DiffFormat) -> String {
-    mark_missing_substr_impl(substr, format)
+pub fn mark_missing_string(string: &str, format: &DiffFormat) -> String {
+    mark_missing_string_impl(string, format)
 }
 
-/// Highlight the given character as "unexpected value" using the color for
+/// Highlights the given character as "unexpected value" using the color for
 /// unexpected values or bold as specified by the given [`DiffFormat`].
 ///
 /// When using this function in comparison to [`mark_unexpected`], the returned
@@ -243,7 +244,7 @@ pub fn mark_unexpected_char(character: char, format: &DiffFormat) -> String {
     mark_unexpected_char_impl(character, format)
 }
 
-/// Highlight the given character as "missing value" using the color for
+/// Highlights the given character as "missing value" using the color for
 /// missing values as specified by the given [`DiffFormat`].
 ///
 /// When using this function in comparison to [`mark_missing`], the returned
@@ -251,6 +252,278 @@ pub fn mark_unexpected_char(character: char, format: &DiffFormat) -> String {
 /// appear in the debug formatted string returned by [`mark_missing`].
 pub fn mark_missing_char(character: char, format: &DiffFormat) -> String {
     mark_missing_char_impl(character, format)
+}
+
+/// Highlights a substring within a string using the color for unexpected values
+/// or bold as specified by the given [`DiffFormat`].
+///
+/// If the string does not contain the substring, a copy of the string is
+/// returned without anything highlighted.
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(not(feature = "colored"))]
+/// # fn main() {}
+/// # #[cfg(feature = "colored")]
+/// # fn main() {
+/// use asserting::colored::{mark_unexpected_substring_in_string, DIFF_FORMAT_RED_YELLOW};
+///
+/// let marked_string = mark_unexpected_substring_in_string(
+///     "mollit est eu amet",
+///     "est eu",
+///     &DIFF_FORMAT_RED_YELLOW,
+/// );
+///
+/// assert_eq!(marked_string, "mollit \u{1b}[31mest eu\u{1b}[0m amet");
+/// # }
+/// ```
+pub fn mark_unexpected_substring_in_string(
+    string: &str,
+    substring: &str,
+    format: &DiffFormat,
+) -> String {
+    mark_substring_in_string(string, substring, format, mark_unexpected_string)
+}
+
+/// Highlights a substring within a string using the color for missing values
+/// as specified by the given [`DiffFormat`].
+///
+/// If the string does not contain the substring, a copy of the string is
+/// returned without anything highlighted.
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(not(feature = "colored"))]
+/// # fn main() {}
+/// # #[cfg(feature = "colored")]
+/// # fn main() {
+/// use asserting::colored::{mark_missing_substring_in_string, DIFF_FORMAT_RED_YELLOW};
+///
+/// let marked_string = mark_missing_substring_in_string(
+///     "mollit est eu amet",
+///     "est eu",
+///     &DIFF_FORMAT_RED_YELLOW,
+/// );
+///
+/// assert_eq!(marked_string, "mollit \u{1b}[33mest eu\u{1b}[0m amet");
+/// # }
+/// ```
+pub fn mark_missing_substring_in_string(
+    string: &str,
+    substring: &str,
+    format: &DiffFormat,
+) -> String {
+    mark_substring_in_string(string, substring, format, mark_missing_string)
+}
+
+fn mark_substring_in_string<F>(
+    string: &str,
+    substring: &str,
+    format: &DiffFormat,
+    mark: F,
+) -> String
+where
+    F: Fn(&str, &DiffFormat) -> String,
+{
+    if let Some(position) = string.find(substring) {
+        let length = substring.len();
+        let begin = &string[..position];
+        let end = &string[position + length..];
+        let marked_substr = mark(substring, format);
+        format!("{begin}{marked_substr}{end}")
+    } else {
+        string.to_string()
+    }
+}
+
+/// Highlights all occurences of a character within a string using the color for
+/// unexpected values or bold as specified by the given [`DiffFormat`].
+///
+/// If the string does not contain the character, a copy of the string is
+/// returned without anything highlighted.
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(not(feature = "colored"))]
+/// # fn main() {}
+/// # #[cfg(feature = "colored")]
+/// # fn main() {
+/// use asserting::colored::{mark_unexpected_char_in_string, DIFF_FORMAT_RED_YELLOW};
+///
+/// let marked_string = mark_unexpected_char_in_string(
+///     "zzril mazim sint",
+///     'z',
+///     &DIFF_FORMAT_RED_YELLOW,
+/// );
+///
+/// assert_eq!(marked_string, "\u{1b}[31mzz\u{1b}[0mril ma\u{1b}[31mz\u{1b}[0mim sint");
+/// # }
+/// ```
+pub fn mark_unexpected_char_in_string(
+    string: &str,
+    character: char,
+    format: &DiffFormat,
+) -> String {
+    mark_char_in_string(string, character, format, mark_unexpected_string)
+}
+
+/// Highlights all occurences of a character within a string using the color for
+/// missing values as specified by the given [`DiffFormat`].
+///
+/// If the string does not contain the character, a copy of the string is
+/// returned without anything highlighted.
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(not(feature = "colored"))]
+/// # fn main() {}
+/// # #[cfg(feature = "colored")]
+/// # fn main() {
+/// use asserting::colored::{mark_missing_char_in_string, DIFF_FORMAT_RED_YELLOW};
+///
+/// let marked_string = mark_missing_char_in_string(
+///     "zzril mazim sint",
+///     'z',
+///     &DIFF_FORMAT_RED_YELLOW,
+/// );
+///
+/// assert_eq!(marked_string, "\u{1b}[33mzz\u{1b}[0mril ma\u{1b}[33mz\u{1b}[0mim sint");
+/// # }
+/// ```
+pub fn mark_missing_char_in_string(string: &str, character: char, format: &DiffFormat) -> String {
+    mark_char_in_string(string, character, format, mark_missing_string)
+}
+
+fn mark_char_in_string<F>(string: &str, character: char, format: &DiffFormat, mark: F) -> String
+where
+    F: Fn(&str, &DiffFormat) -> String,
+{
+    let mut marked_string = String::with_capacity(string.len());
+    let mut parts = string.split(character);
+    let mut chars_to_mark = String::new();
+    parts
+        .next()
+        .iter()
+        .for_each(|part| marked_string.push_str(part));
+    for part in parts {
+        chars_to_mark.push(character);
+        if !part.is_empty() {
+            marked_string.push_str(&mark(&chars_to_mark, format));
+            chars_to_mark.clear();
+            marked_string.push_str(part);
+        }
+    }
+    marked_string
+}
+
+/// Highlights selected characters within a string using the color for
+/// unexpected values or bold as specified by the given [`DiffFormat`].
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(not(feature = "colored"))]
+/// # fn main() {}
+/// # #[cfg(feature = "colored")]
+/// # fn main() {
+/// use asserting::colored::{mark_selected_chars_in_string_as_unexpected, DIFF_FORMAT_RED_YELLOW};
+///
+/// let marked_string = mark_selected_chars_in_string_as_unexpected(
+///     "rebum placerat consetetur",
+///     &[0, 8, 9, 10, 24].into(),
+///     &DIFF_FORMAT_RED_YELLOW,
+/// );
+///
+/// assert_eq!(marked_string, "\u{1b}[31mr\u{1b}[0mebum pl\u{1b}[31mace\u{1b}[0mrat consetetu\u{1b}[31mr\u{1b}[0m");
+/// # }
+/// ```
+pub fn mark_selected_chars_in_string_as_unexpected(
+    string: &str,
+    selected: &HashSet<usize>,
+    format: &DiffFormat,
+) -> String {
+    mark_selected_chars_in_string(string, selected, &format.unexpected)
+}
+
+/// Highlights selected characters within a string using the color for
+/// missing values as specified by the given [`DiffFormat`].
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(not(feature = "colored"))]
+/// # fn main() {}
+/// # #[cfg(feature = "colored")]
+/// # fn main() {
+/// use asserting::colored::{mark_selected_chars_in_string_as_missing, DIFF_FORMAT_RED_YELLOW};
+///
+/// let marked_string = mark_selected_chars_in_string_as_missing(
+///     "rebum placerat consetetur",
+///     &[0, 20, 21].into(),
+///     &DIFF_FORMAT_RED_YELLOW,
+/// );
+///
+/// assert_eq!(marked_string, "\u{1b}[33mr\u{1b}[0mebum placerat conse\u{1b}[33mte\u{1b}[0mtur");
+/// # }
+/// ```
+pub fn mark_selected_chars_in_string_as_missing(
+    string: &str,
+    selected: &HashSet<usize>,
+    format: &DiffFormat,
+) -> String {
+    mark_selected_chars_in_string(string, selected, &format.missing)
+}
+
+fn mark_selected_chars_in_string(
+    string: &str,
+    selected: &HashSet<usize>,
+    highlight: &Highlight,
+) -> String {
+    let mut marked_string = String::with_capacity(string.len());
+    let mut to_mark = selected.iter().copied().collect::<Vec<_>>();
+    to_mark.sort_unstable();
+    let mut to_mark = to_mark.into_iter();
+    let mut last_sel_idx = to_mark.next().unwrap_or(usize::MAX);
+    let mut start_idx = last_sel_idx;
+    let mut end_idx = last_sel_idx;
+    for sel_idx in to_mark.by_ref() {
+        let last_plus_one = last_sel_idx + 1;
+        last_sel_idx = sel_idx;
+        if sel_idx == last_plus_one {
+            end_idx = sel_idx;
+        } else {
+            break;
+        }
+    }
+    for (chr_idx, chr) in string.chars().enumerate() {
+        if chr_idx == start_idx {
+            marked_string.push_str(highlight.start);
+            if last_sel_idx == end_idx {
+                start_idx = usize::MAX;
+            } else {
+                start_idx = last_sel_idx;
+            }
+        }
+        marked_string.push(chr);
+        if chr_idx == end_idx {
+            marked_string.push_str(highlight.end);
+            end_idx = last_sel_idx;
+            for sel_idx in to_mark.by_ref() {
+                let last_plus_one = last_sel_idx + 1;
+                last_sel_idx = sel_idx;
+                if sel_idx == last_plus_one {
+                    end_idx = sel_idx;
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+    marked_string
 }
 
 /// Highlights selected items of a collection using the given [`DiffFormat`].
@@ -385,7 +658,7 @@ where
 /// # fn main() {}
 /// # #[cfg(all(feature = "colored", feature = "std"))]
 /// # fn main() {
-/// use asserting::colored::{mark_missing_substr, mark_selected_entries_in_map, DIFF_FORMAT_RED_BLUE};
+/// use asserting::colored::{mark_missing_string, mark_selected_entries_in_map, DIFF_FORMAT_RED_BLUE};
 /// use hashbrown::HashSet;
 /// use std::collections::BTreeMap;
 ///
@@ -397,7 +670,7 @@ where
 ///     &map_entries,
 ///     &selected_entries,
 ///     &DIFF_FORMAT_RED_BLUE,
-///     mark_missing_substr
+///     mark_missing_string
 /// );
 ///
 /// assert_eq!(marked_map, "{\u{1b}[34m1: \"one\"\u{1b}[0m, 2: \"two\", \u{1b}[34m3: \"three\"\u{1b}[0m, 4: \"four\"}");
@@ -454,7 +727,7 @@ where
 /// # fn main() {}
 /// # #[cfg(all(feature = "colored", feature = "std"))]
 /// # fn main() {
-/// use asserting::colored::{mark_all_entries_in_map, mark_unexpected_substr, DIFF_FORMAT_RED_BLUE};
+/// use asserting::colored::{mark_all_entries_in_map, mark_unexpected_string, DIFF_FORMAT_RED_BLUE};
 /// use std::collections::BTreeMap;
 ///
 /// let map: BTreeMap<_, _> = [(1, "one"), (2, "two"), (3, "three"), (4, "four")].into();
@@ -463,7 +736,7 @@ where
 /// let marked_map = mark_all_entries_in_map(
 ///     &map_entries,
 ///     &DIFF_FORMAT_RED_BLUE,
-///     mark_unexpected_substr
+///     mark_unexpected_string
 /// );
 ///
 /// assert_eq!(marked_map, "{\u{1b}[31m1: \"one\"\u{1b}[0m, \u{1b}[31m2: \"two\"\u{1b}[0m, \u{1b}[31m3: \"three\"\u{1b}[0m, \u{1b}[31m4: \"four\"\u{1b}[0m}");
@@ -521,8 +794,8 @@ mod without_colored_feature {
     #[inline]
     pub fn mark_diff_impl<S, E>(actual: &S, expected: &E, _format: &DiffFormat) -> (String, String)
     where
-        S: Debug,
-        E: Debug,
+        S: Debug + ?Sized,
+        E: Debug + ?Sized,
     {
         (format!("{actual:?}"), format!("{expected:?}"))
     }
@@ -544,13 +817,13 @@ mod without_colored_feature {
     }
 
     #[inline]
-    pub fn mark_unexpected_substr_impl(substr: &str, _format: &DiffFormat) -> String {
-        substr.to_string()
+    pub fn mark_unexpected_string_impl(string: &str, _format: &DiffFormat) -> String {
+        string.to_string()
     }
 
     #[inline]
-    pub fn mark_missing_substr_impl(substr: &str, _format: &DiffFormat) -> String {
-        substr.to_string()
+    pub fn mark_missing_string_impl(string: &str, _format: &DiffFormat) -> String {
+        string.to_string()
     }
 
     #[inline]
@@ -754,8 +1027,8 @@ mod with_colored_feature {
     #[inline]
     pub fn mark_diff_impl<S, E>(actual: &S, expected: &E, format: &DiffFormat) -> (String, String)
     where
-        S: Debug,
-        E: Debug,
+        S: Debug + ?Sized,
+        E: Debug + ?Sized,
     {
         use crate::std::vec::Vec;
         use sdiff::Diff;
@@ -813,16 +1086,16 @@ mod with_colored_feature {
     }
 
     #[inline]
-    pub fn mark_unexpected_substr_impl(substr: &str, format: &DiffFormat) -> String {
+    pub fn mark_unexpected_string_impl(string: &str, format: &DiffFormat) -> String {
         format!(
-            "{}{substr}{}",
+            "{}{string}{}",
             format.unexpected.start, format.unexpected.end
         )
     }
 
     #[inline]
-    pub fn mark_missing_substr_impl(substr: &str, format: &DiffFormat) -> String {
-        format!("{}{substr}{}", format.missing.start, format.missing.end)
+    pub fn mark_missing_string_impl(string: &str, format: &DiffFormat) -> String {
+        format!("{}{string}{}", format.missing.start, format.missing.end)
     }
 
     #[inline]

--- a/src/colored/tests.rs
+++ b/src/colored/tests.rs
@@ -28,6 +28,7 @@ mod without_colored_feature {
 #[cfg(feature = "colored")]
 mod with_colored_feature {
     use super::*;
+    use hashbrown::HashMap;
 
     #[test]
     fn default_diff_format_is_red_green() {
@@ -65,6 +66,247 @@ mod with_colored_feature {
             ",
         ]);
     }
+
+    #[test]
+    fn mark_unexpected_highlights_a_string_with_double_quotes() {
+        let marked_string = mark_unexpected("blandit invidunt", &DIFF_FORMAT_RED_YELLOW);
+
+        assert_that(marked_string).is_equal_to("\u{1b}[31m\"blandit invidunt\"\u{1b}[0m");
+    }
+
+    #[test]
+    fn mark_missing_highlights_a_string_with_double_quotes() {
+        let marked_string = mark_missing("blandit invidunt", &DIFF_FORMAT_RED_YELLOW);
+
+        assert_that(marked_string).is_equal_to("\u{1b}[33m\"blandit invidunt\"\u{1b}[0m");
+    }
+
+    #[test]
+    fn mark_unexpected_string_highlights_a_string_without_double_quotes() {
+        let marked_string = mark_unexpected_string("blandit invidunt", &DIFF_FORMAT_RED_YELLOW);
+
+        assert_that(marked_string).is_equal_to("\u{1b}[31mblandit invidunt\u{1b}[0m");
+    }
+
+    #[test]
+    fn mark_missing_string_highlights_a_string_without_double_quotes() {
+        let marked_string = mark_missing_string("blandit invidunt", &DIFF_FORMAT_RED_YELLOW);
+
+        assert_that(marked_string).is_equal_to("\u{1b}[33mblandit invidunt\u{1b}[0m");
+    }
+
+    #[test]
+    fn mark_unexpected_highlights_a_char_with_single_quotes() {
+        let marked_char = mark_unexpected(&'R', &DIFF_FORMAT_RED_GREEN);
+
+        assert_that(marked_char).is_equal_to("\u{1b}[31m'R'\u{1b}[0m");
+    }
+
+    #[test]
+    fn mark_missing_highlights_a_char_with_single_quotes() {
+        let marked_char = mark_missing(&'R', &DIFF_FORMAT_RED_GREEN);
+
+        assert_that(marked_char).is_equal_to("\u{1b}[32m'R'\u{1b}[0m");
+    }
+
+    #[test]
+    fn mark_unexpected_char_highlights_char_without_single_quotes() {
+        let marked_char = mark_unexpected_char('R', &DIFF_FORMAT_RED_GREEN);
+
+        assert_that(marked_char).is_equal_to("\u{1b}[31mR\u{1b}[0m");
+    }
+
+    #[test]
+    fn mark_missing_char_highlights_char_without_single_quotes() {
+        let marked_char = mark_missing_char('R', &DIFF_FORMAT_RED_GREEN);
+
+        assert_that(marked_char).is_equal_to("\u{1b}[32mR\u{1b}[0m");
+    }
+
+    #[test]
+    fn mark_unexpected_substring_in_string_highlights_a_substring_within_the_string_as_unexpected()
+    {
+        let marked_string = mark_unexpected_substring_in_string(
+            "mollit est eu amet",
+            "st eu a",
+            &DIFF_FORMAT_RED_BLUE,
+        );
+
+        assert_that(marked_string).is_equal_to("mollit e\u{1b}[31mst eu a\u{1b}[0mmet");
+    }
+
+    #[test]
+    fn mark_unexpected_substring_in_string_highlights_nothing_if_the_string_does_not_contain_the_substring(
+    ) {
+        let marked_string = mark_unexpected_substring_in_string(
+            "mollit est eu amet",
+            "st eux a",
+            &DIFF_FORMAT_RED_BLUE,
+        );
+
+        assert_that(marked_string).is_equal_to("mollit est eu amet");
+    }
+
+    #[test]
+    fn mark_missing_substring_in_string_highlights_a_substring_within_the_string_as_missing() {
+        let marked_string = mark_missing_substring_in_string(
+            "mollit est eu amet",
+            "t est eu",
+            &DIFF_FORMAT_RED_BLUE,
+        );
+
+        assert_that(marked_string).is_equal_to("molli\u{1b}[34mt est eu\u{1b}[0m amet");
+    }
+
+    #[test]
+    fn mark_missing_substring_in_string_highlights_nothing_if_the_string_does_not_contain_the_substring(
+    ) {
+        let marked_string = mark_missing_substring_in_string(
+            "mollit est eu amet",
+            "xt est eu",
+            &DIFF_FORMAT_RED_BLUE,
+        );
+
+        assert_that(marked_string).is_equal_to("mollit est eu amet");
+    }
+
+    #[test]
+    fn mark_unexpected_char_in_string_highlights_all_occurences_of_a_char_within_a_string_as_unexpected(
+    ) {
+        let marked_string =
+            mark_unexpected_char_in_string("zzril mazim sint", 'z', &DIFF_FORMAT_RED_YELLOW);
+
+        assert_that(marked_string)
+            .is_equal_to("\u{1b}[31mzz\u{1b}[0mril ma\u{1b}[31mz\u{1b}[0mim sint");
+    }
+
+    #[test]
+    fn mark_unexpected_char_in_string_highlights_nothing_if_the_string_does_not_contain_the_character(
+    ) {
+        let marked_string =
+            mark_unexpected_char_in_string("zzril mazim sint", 'v', &DIFF_FORMAT_RED_YELLOW);
+
+        assert_that(marked_string).is_equal_to("zzril mazim sint");
+    }
+
+    #[test]
+    fn mark_missing_char_in_string_highlights_all_occurences_of_a_char_within_a_string_as_missing()
+    {
+        let marked_string =
+            mark_missing_char_in_string("zzril mazim sint", 'z', &DIFF_FORMAT_RED_YELLOW);
+
+        assert_that(marked_string)
+            .is_equal_to("\u{1b}[33mzz\u{1b}[0mril ma\u{1b}[33mz\u{1b}[0mim sint");
+    }
+
+    #[test]
+    fn mark_missing_char_in_string_highlights_nothing_if_the_string_does_not_contain_the_character()
+    {
+        let marked_string =
+            mark_missing_char_in_string("zzril mazim sint", 'e', &DIFF_FORMAT_RED_YELLOW);
+
+        assert_that(marked_string).is_equal_to("zzril mazim sint");
+    }
+
+    #[test]
+    fn mark_selected_chars_in_string_as_unexpected_highlights_selected_characters_as_unexpected() {
+        let marked_string = mark_selected_chars_in_string_as_unexpected(
+            "rebum placerat consetetur",
+            &[0, 8, 9, 10, 24].into(),
+            &DIFF_FORMAT_RED_YELLOW,
+        );
+
+        assert_that(marked_string).is_equal_to(
+            "\u{1b}[31mr\u{1b}[0mebum pl\u{1b}[31mace\u{1b}[0mrat consetetu\u{1b}[31mr\u{1b}[0m",
+        );
+    }
+
+    #[test]
+    fn mark_selected_chars_in_string_as_unexpected_with_empty_selection_highlights_nothing() {
+        let marked_string = mark_selected_chars_in_string_as_unexpected(
+            "rebum placerat consetetur",
+            &[].into(),
+            &DIFF_FORMAT_RED_YELLOW,
+        );
+
+        assert_that(marked_string).is_equal_to("rebum placerat consetetur");
+    }
+
+    #[test]
+    fn mark_selected_chars_in_string_as_missing_highlights_selected_characters_as_missing() {
+        let marked_string = mark_selected_chars_in_string_as_missing(
+            "rebum placerat consetetur",
+            &[0, 8, 9, 10, 20, 21].into(),
+            &DIFF_FORMAT_RED_YELLOW,
+        );
+
+        assert_that(marked_string).is_equal_to(
+            "\u{1b}[33mr\u{1b}[0mebum pl\u{1b}[33mace\u{1b}[0mrat conse\u{1b}[33mte\u{1b}[0mtur",
+        );
+    }
+
+    #[test]
+    fn mark_selected_chars_in_string_as_missing_with_empty_selection_highlights_nothing() {
+        let marked_string = mark_selected_chars_in_string_as_missing(
+            "rebum placerat consetetur",
+            &[].into(),
+            &DIFF_FORMAT_RED_YELLOW,
+        );
+
+        assert_that(marked_string).is_equal_to("rebum placerat consetetur");
+    }
+
+    #[test]
+    fn mark_selected_items_in_collection_for_empty_collection() {
+        let collection: &[usize] = &[];
+        let selected: HashSet<usize> = [1, 4].into();
+
+        let marked_collection = mark_selected_items_in_collection(
+            collection,
+            &selected,
+            &DIFF_FORMAT_RED_GREEN,
+            mark_missing,
+        );
+
+        assert_that(marked_collection).is_equal_to("[]");
+    }
+
+    #[test]
+    fn mark_all_items_in_collection_for_empty_collection() {
+        let collection: &[usize] = &[];
+
+        let marked_collection =
+            mark_all_items_in_collection(collection, &DIFF_FORMAT_RED_GREEN, mark_missing);
+
+        assert_that(marked_collection).is_equal_to("[]");
+    }
+
+    #[test]
+    fn mark_selected_entries_in_map_for_empty_map() {
+        let map: HashMap<String, usize> = HashMap::new();
+        let map_entries: Vec<_> = map.iter().collect();
+        let selected: HashSet<usize> = [1, 4].into();
+
+        let marked_map = mark_selected_entries_in_map(
+            &map_entries,
+            &selected,
+            &DIFF_FORMAT_RED_GREEN,
+            mark_missing,
+        );
+
+        assert_that(marked_map).is_equal_to("{}");
+    }
+
+    #[test]
+    fn mark_all_entries_in_map_for_empty_map() {
+        let map: HashMap<String, usize> = HashMap::new();
+        let map_entries: Vec<_> = map.iter().collect();
+
+        let marked_map =
+            mark_all_entries_in_map(&map_entries, &DIFF_FORMAT_RED_GREEN, mark_missing);
+
+        assert_that(marked_map).is_equal_to("{}");
+    }
 }
 
 #[cfg(all(feature = "colored", not(feature = "std")))]
@@ -91,7 +333,6 @@ mod with_colored_and_std_features {
     use super::*;
     use crate::colored::with_colored_feature::ENV_VAR_HIGHLIGHT_DIFFS;
     use crate::env;
-    use hashbrown::HashMap;
     use proptest::prelude::*;
 
     #[test]
@@ -295,85 +536,5 @@ mod with_colored_and_std_features {
         let assertion = verify_that_code(|| {});
 
         assert_that(assertion.diff_format()).is_equal_to(&DIFF_FORMAT_NO_HIGHLIGHT);
-    }
-
-    #[test]
-    fn mark_unexpected_highlights_a_char_with_single_quotes() {
-        let marked_char = mark_unexpected(&'R', &DIFF_FORMAT_RED_GREEN);
-
-        assert_that(marked_char).is_equal_to("\u{1b}[31m'R'\u{1b}[0m");
-    }
-
-    #[test]
-    fn mark_missing_highlights_a_char_with_single_quotes() {
-        let marked_char = mark_missing(&'R', &DIFF_FORMAT_RED_GREEN);
-
-        assert_that(marked_char).is_equal_to("\u{1b}[32m'R'\u{1b}[0m");
-    }
-
-    #[test]
-    fn mark_unexpected_char_highlights_char_without_single_quotes() {
-        let marked_char = mark_unexpected_char('R', &DIFF_FORMAT_RED_GREEN);
-
-        assert_that(marked_char).is_equal_to("\u{1b}[31mR\u{1b}[0m");
-    }
-
-    #[test]
-    fn mark_missing_char_highlights_char_without_single_quotes() {
-        let marked_char = mark_missing_char('R', &DIFF_FORMAT_RED_GREEN);
-
-        assert_that(marked_char).is_equal_to("\u{1b}[32mR\u{1b}[0m");
-    }
-
-    #[test]
-    fn mark_selected_items_in_collection_for_empty_collection() {
-        let collection: &[usize] = &[];
-        let selected: HashSet<usize> = [1, 4].into();
-
-        let marked_collection = mark_selected_items_in_collection(
-            collection,
-            &selected,
-            &DIFF_FORMAT_RED_GREEN,
-            mark_missing,
-        );
-
-        assert_that(marked_collection).is_equal_to("[]");
-    }
-
-    #[test]
-    fn mark_all_items_in_collection_for_empty_collection() {
-        let collection: &[usize] = &[];
-
-        let marked_collection =
-            mark_all_items_in_collection(collection, &DIFF_FORMAT_RED_GREEN, mark_missing);
-
-        assert_that(marked_collection).is_equal_to("[]");
-    }
-
-    #[test]
-    fn mark_selected_entries_in_map_for_empty_map() {
-        let map: HashMap<String, usize> = HashMap::new();
-        let map_entries: Vec<_> = map.iter().collect();
-        let selected: HashSet<usize> = [1, 4].into();
-
-        let marked_map = mark_selected_entries_in_map(
-            &map_entries,
-            &selected,
-            &DIFF_FORMAT_RED_GREEN,
-            mark_missing,
-        );
-
-        assert_that(marked_map).is_equal_to("{}");
-    }
-
-    #[test]
-    fn mark_all_entries_in_map_for_empty_map() {
-        let map: HashMap<String, usize> = HashMap::new();
-        let map_entries: Vec<_> = map.iter().collect();
-
-        let marked_map =
-            mark_all_entries_in_map(&map_entries, &DIFF_FORMAT_RED_GREEN, mark_missing);
-
-        assert_that(marked_map).is_equal_to("{}");
     }
 }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,5 +1,5 @@
 use crate::assertions::AssertErrorHasSource;
-use crate::colored::{mark_missing, mark_missing_substr, mark_unexpected, mark_unexpected_substr};
+use crate::colored::{mark_missing, mark_missing_string, mark_unexpected, mark_unexpected_string};
 use crate::expectations::{ErrorHasSource, ErrorHasSourceMessage, Not};
 use crate::spec::{DiffFormat, Expectation, Expression, FailingStrategy, Invertible, Spec};
 use crate::std::error::Error;
@@ -52,7 +52,7 @@ where
             ("a", "<error with some source>")
         };
         let marked_actual = mark_unexpected(actual, format);
-        let marked_expected = mark_missing_substr(expected, format);
+        let marked_expected = mark_missing_string(expected, format);
         format!("expected {expression} to have {a} source\n   but was: {marked_actual}\n  expected: {marked_expected}")
     }
 }
@@ -79,8 +79,8 @@ where
         let not = if inverted { "not " } else { "" };
         let expected = &self.expected_source_message;
         if let Some(actual_source) = actual.source() {
-            let marked_actual = mark_unexpected_substr(&actual_source.to_string(), format);
-            let marked_expected = mark_missing_substr(expected, format);
+            let marked_actual = mark_unexpected_string(&actual_source.to_string(), format);
+            let marked_expected = mark_missing_string(expected, format);
             format!("expected {expression} to have a source message {not}equal to \"{expected}\"\n   but was: \"{marked_actual}\"\n  expected: \"{marked_expected}\"")
         } else {
             let mut marked_actual = mark_unexpected(actual, format);

--- a/src/expectations.rs
+++ b/src/expectations.rs
@@ -330,14 +330,21 @@ mod regex {
     #[must_use]
     pub struct StringMatches<'a> {
         pub pattern: &'a str,
-        pub regex: Result<Regex, regex::Error>,
+        pub regex: Regex,
     }
 
     impl<'a> StringMatches<'a> {
+        /// Creates a new `StringMatches`-expectation.
+        ///
+        /// # Panics
+        ///
+        /// Panics, if the regex pattern is invalid or exceeds the size limit.
         pub fn new(regex_pattern: &'a str) -> Self {
+            let regex = Regex::new(regex_pattern)
+                .unwrap_or_else(|err| panic!("failed to match string with regex: {err}"));
             Self {
                 pattern: regex_pattern,
-                regex: Regex::new(regex_pattern),
+                regex,
             }
         }
     }

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -1,7 +1,7 @@
 use crate::assertions::{AssertMapContainsKey, AssertMapContainsValue};
 use crate::colored::{
     mark_all_entries_in_map, mark_missing, mark_selected_entries_in_map,
-    mark_selected_items_in_collection, mark_unexpected_substr,
+    mark_selected_items_in_collection, mark_unexpected_string,
 };
 use crate::expectations::{
     MapContainsExactlyKeys, MapContainsKey, MapContainsKeys, MapContainsValue, MapContainsValues,
@@ -81,12 +81,12 @@ where
                 &actual_entries,
                 &found,
                 format,
-                mark_unexpected_substr,
+                mark_unexpected_string,
             );
             ("not ", selected_entries_marked)
         } else {
             let all_entries_marked =
-                mark_all_entries_in_map(&actual_entries, format, mark_unexpected_substr);
+                mark_all_entries_in_map(&actual_entries, format, mark_unexpected_string);
             ("", all_entries_marked)
         };
         let marked_expected = mark_missing(&self.expected_key, format);
@@ -137,7 +137,7 @@ where
             &actual_entries,
             &extra_entries,
             format,
-            mark_unexpected_substr,
+            mark_unexpected_string,
         );
         let marked_expected =
             mark_selected_items_in_collection(expected_keys, missing, format, mark_missing);
@@ -188,7 +188,7 @@ where
             }
         }
         let marked_actual =
-            mark_selected_entries_in_map(&actual_entries, &found, format, mark_unexpected_substr);
+            mark_selected_entries_in_map(&actual_entries, &found, format, mark_unexpected_string);
         let marked_expected =
             mark_selected_items_in_collection(expected_keys, extra, format, mark_missing);
         let extra_keys = collect_selected_values(&found, &actual_keys);
@@ -239,7 +239,7 @@ where
         let actual_keys: Vec<_> = actual.keys_property().collect();
 
         let marked_actual =
-            mark_selected_entries_in_map(&actual_entries, extra, format, mark_unexpected_substr);
+            mark_selected_entries_in_map(&actual_entries, extra, format, mark_unexpected_string);
         let marked_expected =
             mark_selected_items_in_collection(expected_keys, missing, format, mark_missing);
         let missing_keys = collect_selected_values(missing, expected_keys);
@@ -316,12 +316,12 @@ where
                 &actual_entries,
                 &found,
                 format,
-                mark_unexpected_substr,
+                mark_unexpected_string,
             );
             ("not ", selected_entries_marked)
         } else {
             let all_entries_marked =
-                mark_all_entries_in_map(&actual_entries, format, mark_unexpected_substr);
+                mark_all_entries_in_map(&actual_entries, format, mark_unexpected_string);
             ("", all_entries_marked)
         };
         let marked_expected = mark_missing(&self.expected_value, format);
@@ -373,7 +373,7 @@ where
             &actual_entries,
             &extra_entries,
             format,
-            mark_unexpected_substr,
+            mark_unexpected_string,
         );
         let marked_expected =
             mark_selected_items_in_collection(expected_values, missing, format, mark_missing);
@@ -427,7 +427,7 @@ where
             }
         }
         let marked_actual =
-            mark_selected_entries_in_map(&actual_entries, &found, format, mark_unexpected_substr);
+            mark_selected_entries_in_map(&actual_entries, &found, format, mark_unexpected_string);
         let marked_expected =
             mark_selected_items_in_collection(expected_values, extra, format, mark_missing);
         let extra_values = collect_selected_values(&found, &actual_values);

--- a/src/number.rs
+++ b/src/number.rs
@@ -3,7 +3,7 @@
 use crate::assertions::{
     AssertDecimalNumber, AssertInfinity, AssertNotANumber, AssertNumericIdentity, AssertSignum,
 };
-use crate::colored::{mark_missing, mark_missing_substr, mark_unexpected};
+use crate::colored::{mark_missing, mark_missing_string, mark_unexpected};
 use crate::expectations::{
     HasPrecisionOf, HasScaleOf, IsANumber, IsFinite, IsInfinite, IsInteger, IsNegative, IsOne,
     IsPositive, IsZero, Not,
@@ -60,7 +60,7 @@ where
             ("", "< 0")
         };
         let marked_actual = mark_unexpected(actual, format);
-        let marked_expected = mark_missing_substr(expected, format);
+        let marked_expected = mark_missing_string(expected, format);
         format!("expected {expression} to be {not}negative\n   but was: {marked_actual}\n  expected: {marked_expected}")
     }
 }
@@ -88,7 +88,7 @@ where
             ("", "> 0")
         };
         let marked_actual = mark_unexpected(actual, format);
-        let marked_expected = mark_missing_substr(expected, format);
+        let marked_expected = mark_missing_string(expected, format);
         format!("expected {expression} to be {not}positive\n   but was: {marked_actual}\n  expected: {marked_expected}")
     }
 }
@@ -192,7 +192,7 @@ where
             ("", "a finite number")
         };
         let marked_actual = mark_unexpected(actual, format);
-        let marked_expected = mark_missing_substr(expected, format);
+        let marked_expected = mark_missing_string(expected, format);
         format!("expected {expression} to be {not}finite\n   but was: {marked_actual}\n  expected: {marked_expected}")
     }
 }
@@ -220,7 +220,7 @@ where
             ("", "an infinite number")
         };
         let marked_actual = mark_unexpected(actual, format);
-        let marked_expected = mark_missing_substr(expected, format);
+        let marked_expected = mark_missing_string(expected, format);
         format!("expected {expression} to be {not}infinite\n   but was: {marked_actual}\n  expected: {marked_expected}")
     }
 }
@@ -262,7 +262,7 @@ where
             ("", "a number")
         };
         let marked_actual = mark_unexpected(actual, format);
-        let marked_expected = mark_missing_substr(expected, format);
+        let marked_expected = mark_missing_string(expected, format);
         format!("expected {expression} to be {not}a number\n   but was: {marked_actual}\n  expected: {marked_expected}")
     }
 }
@@ -356,7 +356,7 @@ where
             ("", "an integer value")
         };
         let marked_actual = mark_unexpected(&actual, format);
-        let marked_expected = mark_missing_substr(expected, format);
+        let marked_expected = mark_missing_string(expected, format);
         format!("expected {expression} to be {not}an integer value\n   but was: {marked_actual}\n  expected: {marked_expected}")
     }
 }

--- a/src/panic/mod.rs
+++ b/src/panic/mod.rs
@@ -1,7 +1,7 @@
 //! Implementation of assertions for code that should or should not panic.
 
 use crate::assertions::AssertCodePanics;
-use crate::colored::{mark_missing_substr, mark_unexpected_substr};
+use crate::colored::{mark_missing_string, mark_unexpected_string};
 use crate::expectations::{DoesNotPanic, DoesPanic};
 use crate::spec::{Code, DiffFormat, Expectation, Expression, FailingStrategy, Spec};
 use crate::std::any::Any;
@@ -63,8 +63,8 @@ where
         if panic_message == ONLY_ONE_EXPECTATION {
             format!("error in test assertion: {ONLY_ONE_EXPECTATION}")
         } else {
-            let marked_did_panic = mark_unexpected_substr("did panic", format);
-            let marked_panic_message = mark_unexpected_substr(&panic_message, format);
+            let marked_did_panic = mark_unexpected_string("did panic", format);
+            let marked_panic_message = mark_unexpected_string(&panic_message, format);
             format!(
                 "expected {expression} to not panic, but {marked_did_panic}\n  with message: \"{marked_panic_message}\""
             )
@@ -111,18 +111,18 @@ where
             if actual_message == ONLY_ONE_EXPECTATION {
                 format!("error in test assertion: {ONLY_ONE_EXPECTATION}")
             } else if let Some(expected_message) = &self.expected_message {
-                let marked_expected_message = mark_missing_substr(expected_message, format);
-                let marked_actual_message = mark_unexpected_substr(actual_message, format);
+                let marked_expected_message = mark_missing_string(expected_message, format);
+                let marked_actual_message = mark_unexpected_string(actual_message, format);
                 format!("expected {expression} to panic with message {expected_message:?}\n   but was: \"{marked_actual_message}\"\n  expected: \"{marked_expected_message}\"")
             } else {
                 // should be unreachable
                 format!("expected {expression} to panic, but did not panic")
             }
         } else if let Some(expected_message) = &self.expected_message {
-            let marked_did_not_panic = mark_unexpected_substr("did not panic", format);
+            let marked_did_not_panic = mark_unexpected_string("did not panic", format);
             format!("expected {expression} to panic with message {expected_message:?},\n  but {marked_did_not_panic}")
         } else {
-            let marked_did_not_panic = mark_unexpected_substr("did not panic", format);
+            let marked_did_not_panic = mark_unexpected_string("did not panic", format);
             format!("expected {expression} to panic, but {marked_did_not_panic}")
         }
     }

--- a/src/range/mod.rs
+++ b/src/range/mod.rs
@@ -1,7 +1,7 @@
 //! Implementation of assertions for `Range` and `RangeInclusive` values.
 
 use crate::assertions::AssertInRange;
-use crate::colored::{mark_missing, mark_missing_substr, mark_unexpected};
+use crate::colored::{mark_missing, mark_missing_string, mark_unexpected};
 use crate::expectations::{IsInRange, Not};
 use crate::properties::IsEmptyProperty;
 use crate::spec::{DiffFormat, Expectation, Expression, FailingStrategy, Invertible, Spec};
@@ -71,12 +71,12 @@ where
             let marked_expected_start = match self.expected_range.start_bound() {
                 Bound::Included(start) => format!("< {}", mark_missing(start, format)),
                 Bound::Excluded(start) => format!("<= {}", mark_missing(start, format)),
-                Bound::Unbounded => format!("< {}", mark_missing_substr("..", format)),
+                Bound::Unbounded => format!("< {}", mark_missing_string("..", format)),
             };
             let marked_expected_end = match self.expected_range.end_bound() {
                 Bound::Included(end) => format!("> {}", mark_missing(end, format)),
                 Bound::Excluded(end) => format!(">= {}", mark_missing(end, format)),
-                Bound::Unbounded => format!("> {}", mark_missing_substr("..", format)),
+                Bound::Unbounded => format!("> {}", mark_missing_string("..", format)),
             };
 
             (
@@ -99,7 +99,7 @@ where
                         format!("{start:?} <")
                     }
                 },
-                Bound::Unbounded => format!("{} <", mark_missing_substr("..", format)),
+                Bound::Unbounded => format!("{} <", mark_missing_string("..", format)),
             };
             let marked_expected_end = match self.expected_range.end_bound() {
                 Bound::Included(end) => {
@@ -116,7 +116,7 @@ where
                         format!("< {end:?}")
                     }
                 },
-                Bound::Unbounded => format!("< {}", mark_missing_substr("..", format)),
+                Bound::Unbounded => format!("< {}", mark_missing_string("..", format)),
             };
 
             (

--- a/src/string/tests.rs
+++ b/src/string/tests.rs
@@ -784,6 +784,180 @@ fn verify_str_contains_any_char_of_a_borrowed_array_of_chars_fails() {
 }
 
 #[test]
+fn string_does_not_contain_other_str() {
+    let subject: String = "illum kasd nostrud possim".to_string();
+
+    assert_that(subject).does_not_contain("laboris");
+}
+
+#[test]
+fn string_does_not_contain_other_string() {
+    let subject: String = "consectetuer nulla anim nihil".to_string();
+
+    assert_that(subject).does_not_contain("doming".to_string());
+}
+
+#[test]
+fn str_does_not_contain_other_str() {
+    let subject: &str = "consectetuer duis quis veniam";
+
+    assert_that(subject).does_not_contain("duis veniam");
+}
+
+#[test]
+fn str_does_not_contain_other_string() {
+    let subject: &str = "voluptua liber assum facilisis";
+
+    assert_that(subject).does_not_contain("tue liber assum".to_string());
+}
+
+#[test]
+fn str_does_not_contain_a_char() {
+    let subject: &str = "praesent doming liber accusam";
+
+    assert_that(subject).does_not_contain('v');
+}
+
+#[test]
+fn verify_string_does_not_contain_other_str_fails() {
+    let subject: String = "invidunt eos hendrerit commodo".to_string();
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .does_not_contain(" eos ")
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r#"assertion failed: expected my_thing to not contain " eos "
+   but was: "invidunt eos hendrerit commodo"
+  expected: not " eos "
+"#
+        ]
+    );
+}
+
+#[test]
+fn verify_string_does_not_contain_other_string_fails() {
+    let subject: String = "invidunt eos hendrerit commodo".to_string();
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .does_not_contain("eos hend".to_string())
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r#"assertion failed: expected my_thing to not contain "eos hend"
+   but was: "invidunt eos hendrerit commodo"
+  expected: not "eos hend"
+"#
+        ]
+    );
+}
+
+#[test]
+fn verify_string_does_not_contain_char_fails() {
+    let subject: String = "consectetur ex hendrerit officia".to_string();
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .does_not_contain('x')
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[r#"assertion failed: expected my_thing to not contain 'x'
+   but was: "consectetur ex hendrerit officia"
+  expected: not 'x'
+"#]
+    );
+}
+
+#[test]
+fn string_does_not_contain_any_char_of_a_slice_of_chars() {
+    let subject: String = "dolore reprehenderit erat duis".to_string();
+
+    assert_that(subject).does_not_contain_any_of(&['v', 'm', 'z', 'b'][..]);
+}
+
+#[test]
+fn str_does_not_contain_any_char_of_an_array_of_chars() {
+    let subject: &str = "duo excepteur invidunt nonumy";
+
+    assert_that(subject).does_not_contain_any_of(['b', 'a', 'z']);
+}
+
+#[test]
+fn string_does_not_contain_any_char_of_a_borrowed_array_of_chars() {
+    let subject: String = "sadipscing nibh nisi voluptua".to_string();
+
+    assert_that(subject).does_not_contain_any_of(&['q', 'x', 'k', 'm', 'r']);
+}
+
+#[test]
+fn verify_str_does_not_contain_any_char_of_a_slice_of_chars_fails() {
+    let subject: &str = "luptatum in nihil laoreet";
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .does_not_contain_any_of(&['x', 'n', 'z'][..])
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r#"assertion failed: expected my_thing to not contain any of ['x', 'n', 'z']
+   but was: "luptatum in nihil laoreet"
+  expected: not ['x', 'n', 'z']
+"#
+        ]
+    );
+}
+
+#[test]
+fn verify_string_does_not_contain_any_char_of_an_array_of_chars_fails() {
+    let subject: String = "luptatum in nihil laoreet".to_string();
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .does_not_contain_any_of(['d', 'k', 'n'])
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r#"assertion failed: expected my_thing to not contain any of ['d', 'k', 'n']
+   but was: "luptatum in nihil laoreet"
+  expected: not ['d', 'k', 'n']
+"#
+        ]
+    );
+}
+
+#[test]
+fn verify_str_does_not_contain_any_char_of_a_borrowed_array_of_chars_fails() {
+    let subject: &str = "luptatum in nihil laoreet";
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .does_not_contain_any_of(&['u', 'a', 'l'])
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r#"assertion failed: expected my_thing to not contain any of ['u', 'a', 'l']
+   but was: "luptatum in nihil laoreet"
+  expected: not ['u', 'a', 'l']
+"#
+        ]
+    );
+}
+
+#[test]
 fn string_starts_with_str() {
     let subject: String = "wisi option excepteur labore".to_string();
 
@@ -983,6 +1157,206 @@ fn verify_string_ends_with_char_fails() {
     );
 }
 
+#[test]
+fn string_does_not_start_with_str() {
+    let subject: String = "wisi option excepteur labore".to_string();
+
+    assert_that(subject).does_not_start_with("vidi");
+}
+
+#[test]
+fn string_does_not_start_with_string() {
+    let subject: String = "sanctus stet eirmod voluptate".to_string();
+
+    assert_that(subject).does_not_start_with("sandusen ".to_string());
+}
+
+#[test]
+fn string_does_not_start_with_char() {
+    let subject: String = "odio gubergren aliquip blandit".to_string();
+
+    assert_that(subject).does_not_start_with('v');
+}
+
+#[test]
+fn str_does_not_start_with_str() {
+    let subject: &str = "stet nam consetetur placerat";
+
+    assert_that(subject).does_not_start_with("stet ma");
+}
+
+#[test]
+fn str_does_not_start_with_string() {
+    let subject: &str = "dolores invidunt exerci nostrud";
+
+    assert_that(subject).does_not_start_with("color".to_string());
+}
+
+#[test]
+fn str_does_not_start_with_char() {
+    let subject: &str = "odio gubergren aliquip blandit";
+
+    assert_that(subject).does_not_start_with('m');
+}
+
+#[test]
+fn verify_string_does_not_start_with_str_fails() {
+    let subject: String = "possim deserunt obcaecat hendrerit".to_string();
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .does_not_start_with("possim des")
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r#"assertion failed: expected my_thing to not start with "possim des"
+   but was: "possim deserunt obcaecat hendrerit"
+  expected: not "possim des"
+"#
+        ]
+    );
+}
+
+#[test]
+fn verify_string_does_not_start_with_string_fails() {
+    let subject: String = "possim deserunt obcaecat hendrerit".to_string();
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .does_not_start_with("poss".to_string())
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r#"assertion failed: expected my_thing to not start with "poss"
+   but was: "possim deserunt obcaecat hendrerit"
+  expected: not "poss"
+"#
+        ]
+    );
+}
+
+#[test]
+fn verify_string_does_not_start_with_char_fails() {
+    let subject: String = "possim deserunt obcaecat hendrerit".to_string();
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .does_not_start_with('p')
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[r#"assertion failed: expected my_thing to not start with 'p'
+   but was: "possim deserunt obcaecat hendrerit"
+  expected: not 'p'
+"#]
+    );
+}
+
+#[test]
+fn string_does_not_end_with_str() {
+    let subject: String = "wisi option excepteur labore".to_string();
+
+    assert_that(subject).does_not_end_with("libory");
+}
+
+#[test]
+fn string_does_not_end_with_string() {
+    let subject: String = "sanctus stet eirmod voluptate".to_string();
+
+    assert_that(subject).does_not_end_with(" volerate".to_string());
+}
+
+#[test]
+fn string_does_not_end_with_char() {
+    let subject: String = "odio gubergren aliquip blandit".to_string();
+
+    assert_that(subject).does_not_end_with('i');
+}
+
+#[test]
+fn str_does_not_end_with_str() {
+    let subject: &str = "stet nam consetetur placerat";
+
+    assert_that(subject).does_not_end_with("etur benerat");
+}
+
+#[test]
+fn str_does_not_end_with_string() {
+    let subject: &str = "dolores invidunt exerci nostrud";
+
+    assert_that(subject).does_not_end_with("tru".to_string());
+}
+
+#[test]
+fn str_does_not_end_with_char() {
+    let subject: &str = "odio gubergren aliquip blandit";
+
+    assert_that(subject).does_not_end_with('v');
+}
+
+#[test]
+fn verify_string_does_not_end_with_str_fails() {
+    let subject: String = "possim deserunt obcaecat hendrerit".to_string();
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .does_not_end_with("rerit")
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r#"assertion failed: expected my_thing to not end with "rerit"
+   but was: "possim deserunt obcaecat hendrerit"
+  expected: not "rerit"
+"#
+        ]
+    );
+}
+
+#[test]
+fn verify_string_does_not_end_with_string_fails() {
+    let subject: String = "possim deserunt obcaecat hendrerit".to_string();
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .does_not_end_with("caecat hendrerit".to_string())
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r#"assertion failed: expected my_thing to not end with "caecat hendrerit"
+   but was: "possim deserunt obcaecat hendrerit"
+  expected: not "caecat hendrerit"
+"#
+        ]
+    );
+}
+
+#[test]
+fn verify_string_does_not_end_with_char_fails() {
+    let subject: String = "possim deserunt obcaecat hendrerit".to_string();
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .does_not_end_with('t')
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[r#"assertion failed: expected my_thing to not end with 't'
+   but was: "possim deserunt obcaecat hendrerit"
+  expected: not 't'
+"#]
+    );
+}
+
 #[cfg(feature = "regex")]
 mod regex {
     use crate::prelude::*;
@@ -1015,44 +1389,54 @@ mod regex {
     }
 
     #[test]
-    fn verify_string_matches_regex_given_an_invalid_regex_fails() {
-        let subject: String = "s3cr3tPass".to_string();
+    fn string_does_not_match_regex() {
+        let subject: String = "tincidunt\tLaoreet ❤ Molestie eros".to_string();
+
+        assert_that(subject).does_not_match(r"^[a-zA-Z0-9 ]{8,32}$");
+    }
+
+    #[test]
+    fn verify_string_does_not_match_regex_fails() {
+        let subject: String = "volutpat lobortis aliquam diam".to_string();
 
         let failures = verify_that(subject)
-            .named("password")
-            .matches(r"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{8,32}$")
+            .named("my_thing")
+            .does_not_match(r"^[a-zA-Z0-9 ]{8,32}$")
             .display_failures();
 
         assert_eq!(
             failures,
             &[
-                r"assertion failed: expected password to match the regex ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{8,32}$
-  but the regex can not be compiled: regex parse error:
-    ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{8,32}$
-     ^^^
-error: look-around, including look-ahead and look-behind, is not supported
+                r"assertion failed: expected my_thing to not match the regex ^[a-zA-Z0-9 ]{8,32}$
+               but was: volutpat lobortis aliquam diam
+      does match regex: ^[a-zA-Z0-9 ]{8,32}$
 "
             ]
         );
     }
 
     #[test]
-    fn verify_string_matcher_regex_given_regex_exceeds_default_size_limit_failes() {
+    #[should_panic = r"failed to match string with regex: regex parse error:
+    ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{8,32}$
+     ^^^
+error: look-around, including look-ahead and look-behind, is not supported"]
+    fn string_matches_regex_given_an_invalid_regex_panics() {
         let subject: String = "s3cr3tPass".to_string();
 
-        let failures = verify_that(subject)
-            .named("my_thing")
-            .matches(r"^(\/[\w-]{1,255}){1,64}\/?$")
-            .display_failures();
+        assert_that(subject)
+            .named("password")
+            .matches(r"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{8,32}$");
+    }
 
-        assert_eq!(
-            failures,
-            &[
-                r"assertion failed: expected my_thing to match the regex ^(\/[\w-]{1,255}){1,64}\/?$
-  but the compiled regex exceeds the size limit of 10485760 bytes
-"
-            ]
-        );
+    #[test]
+    #[should_panic = "failed to match string with regex: Compiled regex exceeds size limit of 10485760 bytes"]
+    fn string_matches_regex_given_regex_exceeds_default_size_limit_panics() {
+        let subject: String = "s3cr3tPass".to_string();
+
+        assert_that(subject)
+            .named("my_thing")
+            .with_diff_format(DIFF_FORMAT_RED_GREEN)
+            .matches(r"^(\/[\w-]{1,255}){1,64}\/?$");
     }
 }
 
@@ -1230,6 +1614,64 @@ mod colored {
     }
 
     #[test]
+    fn highlight_diffs_string_does_not_contain_str() {
+        let subject = "sanctus stet eiusmod odio".to_string();
+
+        let failures = verify_that(subject)
+            .with_diff_format(DIFF_FORMAT_RED_YELLOW)
+            .does_not_contain("stet eius")
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[
+                "assertion failed: expected subject to not contain \"stet eius\"\n   \
+                    but was: \"sanctus \u{1b}[31mstet eius\u{1b}[0mmod odio\"\n  \
+                   expected: not \"\u{1b}[33mstet eius\u{1b}[0m\"\n\
+                "
+            ]
+        );
+    }
+
+    #[test]
+    fn highlight_diffs_string_does_not_contain_string() {
+        let subject = "sanctus stet eiusmod odio".to_string();
+
+        let failures = verify_that(subject)
+            .with_diff_format(DIFF_FORMAT_RED_YELLOW)
+            .does_not_contain("stet eius".to_string())
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[
+                "assertion failed: expected subject to not contain \"stet eius\"\n   \
+                    but was: \"sanctus \u{1b}[31mstet eius\u{1b}[0mmod odio\"\n  \
+                   expected: not \"\u{1b}[33mstet eius\u{1b}[0m\"\n\
+                "
+            ]
+        );
+    }
+
+    #[test]
+    fn highlight_diffs_string_does_not_contain_char() {
+        let subject = "sanctus stett eiusmod odio".to_string();
+
+        let failures = verify_that(subject)
+            .with_diff_format(DIFF_FORMAT_RED_YELLOW)
+            .does_not_contain('t')
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &["assertion failed: expected subject to not contain 't'\n   \
+                 but was: \"sanc\u{1b}[31mt\u{1b}[0mus s\u{1b}[31mt\u{1b}[0me\u{1b}[31mtt\u{1b}[0m eiusmod odio\"\n  \
+                expected: not '\u{1b}[33mt\u{1b}[0m'\n\
+            "]
+        );
+    }
+
+    #[test]
     fn highlight_diffs_string_starts_with_str() {
         let subject = "nulla feugiat illum culpa".to_string();
 
@@ -1270,6 +1712,46 @@ mod colored {
     }
 
     #[test]
+    fn highlight_diffs_string_does_not_start_with_str() {
+        let subject = "nulla feugiat illum culpa".to_string();
+
+        let failures = verify_that(subject)
+            .with_diff_format(DIFF_FORMAT_RED_GREEN)
+            .does_not_start_with("null")
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[
+                "assertion failed: expected subject to not start with \"null\"\n   \
+                   but was: \"\u{1b}[31mnull\u{1b}[0ma feugiat illum culpa\"\n  \
+                  expected: not \"\u{1b}[32mnull\u{1b}[0m\"\n\
+            "
+            ]
+        );
+    }
+
+    #[test]
+    fn highlight_diffs_string_does_not_start_with_string() {
+        let subject = "nulla feugiat illum culpa".to_string();
+
+        let failures = verify_that(subject)
+            .with_diff_format(DIFF_FORMAT_RED_GREEN)
+            .does_not_start_with("null".to_string())
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[
+                "assertion failed: expected subject to not start with \"null\"\n   \
+                    but was: \"\u{1b}[31mnull\u{1b}[0ma feugiat illum culpa\"\n  \
+                   expected: not \"\u{1b}[32mnull\u{1b}[0m\"\n\
+            "
+            ]
+        );
+    }
+
+    #[test]
     fn highlight_diffs_string_starts_with_char() {
         let subject = "commodo sadipscing id imperdiet".to_string();
 
@@ -1284,6 +1766,26 @@ mod colored {
                    but was: \"\u{1b}[31mc\u{1b}[0mommodo sadipscing id imperdiet\"\n  \
                   expected: '\u{1b}[32mo\u{1b}[0m'\n\
             "]
+        );
+    }
+
+    #[test]
+    fn highlight_diffs_string_does_not_start_with_char() {
+        let subject = "commodo sadipscing id imperdiet".to_string();
+
+        let failures = verify_that(subject)
+            .with_diff_format(DIFF_FORMAT_RED_GREEN)
+            .does_not_start_with('c')
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[
+                "assertion failed: expected subject to not start with 'c'\n   \
+                   but was: \"\u{1b}[31mc\u{1b}[0mommodo sadipscing id imperdiet\"\n  \
+                  expected: not '\u{1b}[32mc\u{1b}[0m'\n\
+            "
+            ]
         );
     }
 
@@ -1328,6 +1830,46 @@ mod colored {
     }
 
     #[test]
+    fn highlight_diffs_string_does_not_end_with_str() {
+        let subject = "nulla feugiat illum culpa".to_string();
+
+        let failures = verify_that(subject)
+            .with_diff_format(DIFF_FORMAT_RED_GREEN)
+            .does_not_end_with("um culpa")
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[
+                "assertion failed: expected subject to not end with \"um culpa\"\n   \
+                   but was: \"nulla feugiat ill\u{1b}[31mum culpa\u{1b}[0m\"\n  \
+                  expected: not \"\u{1b}[32mum culpa\u{1b}[0m\"\n\
+            "
+            ]
+        );
+    }
+
+    #[test]
+    fn highlight_diffs_string_does_not_end_with_string() {
+        let subject = "nulla feugiat illum culpa".to_string();
+
+        let failures = verify_that(subject)
+            .with_diff_format(DIFF_FORMAT_RED_GREEN)
+            .does_not_end_with("lpa".to_string())
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[
+                "assertion failed: expected subject to not end with \"lpa\"\n   \
+                    but was: \"nulla feugiat illum cu\u{1b}[31mlpa\u{1b}[0m\"\n  \
+                   expected: not \"\u{1b}[32mlpa\u{1b}[0m\"\n\
+                "
+            ]
+        );
+    }
+
+    #[test]
     fn highlight_diffs_string_ends_with_char() {
         let subject = "commodo sadipscing id imperdiet".to_string();
 
@@ -1346,6 +1888,26 @@ mod colored {
     }
 
     #[test]
+    fn highlight_diffs_string_does_not_end_with_char() {
+        let subject = "commodo sadipscing id imperdiet".to_string();
+
+        let failures = verify_that(subject)
+            .with_diff_format(DIFF_FORMAT_RED_GREEN)
+            .does_not_end_with('t')
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[
+                "assertion failed: expected subject to not end with 't'\n   \
+                   but was: \"commodo sadipscing id imperdie\u{1b}[31mt\u{1b}[0m\"\n  \
+                  expected: not '\u{1b}[32mt\u{1b}[0m'\n\
+            "
+            ]
+        );
+    }
+
+    #[test]
     fn highlight_diffs_string_contains_any_of_a_char_slice() {
         let subject = "proident tempor est sed".to_string();
 
@@ -1358,7 +1920,7 @@ mod colored {
             failures,
             &[
                 "assertion failed: expected subject to contain any of ['a', 'b', 'c']\n   \
-                    but was: \u{1b}[31m\"proident tempor est sed\"\u{1b}[0m\n  \
+                    but was: \"\u{1b}[31mproident tempor est sed\u{1b}[0m\"\n  \
                    expected: \u{1b}[34m['a', 'b', 'c']\u{1b}[0m\n\
                 "
             ]
@@ -1378,7 +1940,7 @@ mod colored {
             failures,
             &[
                 "assertion failed: expected subject to contain any of ['a', 'b', 'c']\n   \
-                    but was: \u{1b}[31m\"proident tempor est sed\"\u{1b}[0m\n  \
+                    but was: \"\u{1b}[31mproident tempor est sed\u{1b}[0m\"\n  \
                    expected: \u{1b}[34m['a', 'b', 'c']\u{1b}[0m\n\
                 "
             ]
@@ -1398,8 +1960,68 @@ mod colored {
             failures,
             &[
                 "assertion failed: expected subject to contain any of ['a', 'b', 'c']\n   \
-                    but was: \u{1b}[31m\"proident tempor est sed\"\u{1b}[0m\n  \
+                    but was: \"\u{1b}[31mproident tempor est sed\u{1b}[0m\"\n  \
                    expected: \u{1b}[34m['a', 'b', 'c']\u{1b}[0m\n\
+                "
+            ]
+        );
+    }
+
+    #[test]
+    fn highlight_diffs_string_does_not_contain_any_of_a_char_slice() {
+        let subject = "proident tempor est sed".to_string();
+
+        let failures = verify_that(subject)
+            .with_diff_format(DIFF_FORMAT_RED_BLUE)
+            .does_not_contain_any_of(&['r', 'b', 'c'][..])
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[
+                "assertion failed: expected subject to not contain any of ['r', 'b', 'c']\n   \
+                    but was: \"p\u{1b}[31mr\u{1b}[0moident tempo\u{1b}[31mr\u{1b}[0m est sed\"\n  \
+                   expected: not [\u{1b}[34m'r'\u{1b}[0m, 'b', 'c']\n\
+                "
+            ]
+        );
+    }
+
+    #[test]
+    fn highlight_diffs_string_does_not_contain_any_of_a_char_array() {
+        let subject = "proident tempor est sed".to_string();
+
+        let failures = verify_that(subject)
+            .with_diff_format(DIFF_FORMAT_RED_BLUE)
+            .does_not_contain_any_of(['a', 's', 'e'])
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[
+                "assertion failed: expected subject to not contain any of ['a', 's', 'e']\n   \
+                    but was: \"proid\u{1b}[31me\u{1b}[0mnt t\u{1b}[31me\u{1b}[0mmpor \u{1b}[31mes\u{1b}[0mt \u{1b}[31mse\u{1b}[0md\"\n  \
+                   expected: not ['a', \u{1b}[34m's'\u{1b}[0m, \u{1b}[34m'e'\u{1b}[0m]\n\
+                "
+            ]
+        );
+    }
+
+    #[test]
+    fn highlight_diffs_string_does_not_contain_any_of_a_borrowed_char_array() {
+        let subject = "proident tempor est sed".to_string();
+
+        let failures = verify_that(subject)
+            .with_diff_format(DIFF_FORMAT_RED_BLUE)
+            .does_not_contain_any_of(&['p', 'o', 'r'])
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &[
+                "assertion failed: expected subject to not contain any of ['p', 'o', 'r']\n   \
+                    but was: \"\u{1b}[31mpro\u{1b}[0mident tem\u{1b}[31mpor\u{1b}[0m est sed\"\n  \
+                   expected: not [\u{1b}[34m'p'\u{1b}[0m, \u{1b}[34m'o'\u{1b}[0m, \u{1b}[34m'r'\u{1b}[0m]\n\
                 "
             ]
         );
@@ -1412,7 +2034,7 @@ mod colored_regex {
     use crate::std::string::ToString;
 
     #[test]
-    fn verify_string_matches_regex_fails() {
+    fn highlight_diffs_string_matches_regex() {
         let subject: String = "volutpat lobortis aliquam diam".to_string();
 
         let failures = verify_that(subject)
@@ -1433,43 +2055,21 @@ mod colored_regex {
     }
 
     #[test]
-    fn verify_string_matches_regex_given_an_invalid_regex_fails() {
-        let subject: String = "s3cr3tPass".to_string();
-
-        let failures = verify_that(subject)
-            .named("password")
-            .with_diff_format(DIFF_FORMAT_RED_GREEN)
-            .matches(r"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{8,32}$")
-            .display_failures();
-
-        assert_eq!(
-            failures,
-            &[
-                "assertion failed: expected password to match the regex ^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[a-zA-Z\\d]{8,32}$\n  \
-                   but the regex can not be compiled: \u{1b}[31mregex parse error:\n    \
-                     ^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[a-zA-Z\\d]{8,32}$\n     \
-                      ^^^\n\
-                 error: look-around, including look-ahead and look-behind, is not supported\u{1b}[0m\n\
-"
-            ]
-        );
-    }
-
-    #[test]
-    fn verify_string_matcher_regex_given_regex_exceeds_default_size_limit_failes() {
-        let subject: String = "s3cr3tPass".to_string();
+    fn highlight_diffs_string_does_not_match_regex() {
+        let subject: String = "volutpat lobortis aliquam diam".to_string();
 
         let failures = verify_that(subject)
             .named("my_thing")
-            .with_diff_format(DIFF_FORMAT_RED_GREEN)
-            .matches(r"^(\/[\w-]{1,255}){1,64}\/?$")
+            .with_diff_format(DIFF_FORMAT_RED_YELLOW)
+            .does_not_match(r"^[a-zA-Z0-9 ]{8,32}$")
             .display_failures();
 
         assert_eq!(
             failures,
             &[
-                "assertion failed: expected my_thing to match the regex ^(\\/[\\w-]{1,255}){1,64}\\/?$\n  \
-                   but \u{1b}[31mthe compiled regex exceeds the size limit of 10485760 bytes\u{1b}[0m\n\
+                "assertion failed: expected my_thing to not match the regex ^[a-zA-Z0-9 ]{8,32}$\n               \
+                             but was: \u{1b}[31mvolutpat lobortis aliquam diam\u{1b}[0m\n      \
+                    does match regex: \u{1b}[33m^[a-zA-Z0-9 ]{8,32}$\u{1b}[0m\n\
                 "
             ]
         );


### PR DESCRIPTION
It would be useful if the string specific assertions have a "does not..." variant.

Implemented "does not..." assertions for strings:

* `does_not_contain`
* `does_not_start_with`
* `does_not_end_with`
* `does_not_contain_any_of`
* `does_not_match` (requires crate feature `regex`)