### PR TITLE
feat: provide constructor functions for expectations

### DIFF
--- a/src/boolean/mod.rs
+++ b/src/boolean/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::assertions::AssertBoolean;
 use crate::colored::{mark_missing, mark_unexpected};
-use crate::expectations::{IsFalse, IsTrue};
+use crate::expectations::{is_false, is_true, IsFalse, IsTrue};
 use crate::spec::{DiffFormat, Expectation, Expression, FailingStrategy, Invertible, Spec};
 use crate::std::format;
 use crate::std::string::String;
@@ -12,11 +12,11 @@ where
     R: FailingStrategy,
 {
     fn is_true(self) -> Self {
-        self.expecting(IsTrue)
+        self.expecting(is_true())
     }
 
     fn is_false(self) -> Self {
-        self.expecting(IsFalse)
+        self.expecting(is_false())
     }
 }
 

--- a/src/char/mod.rs
+++ b/src/char/mod.rs
@@ -1,8 +1,9 @@
 use crate::assertions::AssertChar;
 use crate::colored::{mark_missing_string, mark_unexpected_char};
 use crate::expectations::{
-    IsAlphabetic, IsAlphanumeric, IsAscii, IsControlChar, IsDigit, IsLowerCase, IsUpperCase,
-    IsWhitespace,
+    is_alphabetic, is_alphanumeric, is_ascii, is_control_char, is_digit, is_lower_case,
+    is_upper_case, is_whitespace, IsAlphabetic, IsAlphanumeric, IsAscii, IsControlChar, IsDigit,
+    IsLowerCase, IsUpperCase, IsWhitespace,
 };
 use crate::spec::{DiffFormat, Expectation, Expression, FailingStrategy, Invertible, Spec};
 use crate::std::format;
@@ -13,35 +14,35 @@ where
     R: FailingStrategy,
 {
     fn is_lowercase(self) -> Self {
-        self.expecting(IsLowerCase)
+        self.expecting(is_lower_case())
     }
 
     fn is_uppercase(self) -> Self {
-        self.expecting(IsUpperCase)
+        self.expecting(is_upper_case())
     }
 
     fn is_ascii(self) -> Self {
-        self.expecting(IsAscii)
+        self.expecting(is_ascii())
     }
 
     fn is_alphabetic(self) -> Self {
-        self.expecting(IsAlphabetic)
+        self.expecting(is_alphabetic())
     }
 
     fn is_alphanumeric(self) -> Self {
-        self.expecting(IsAlphanumeric)
+        self.expecting(is_alphanumeric())
     }
 
     fn is_control_char(self) -> Self {
-        self.expecting(IsControlChar)
+        self.expecting(is_control_char())
     }
 
     fn is_digit(self, radix: u32) -> Self {
-        self.expecting(IsDigit { radix })
+        self.expecting(is_digit(radix))
     }
 
     fn is_whitespace(self) -> Self {
-        self.expecting(IsWhitespace)
+        self.expecting(is_whitespace())
     }
 }
 
@@ -50,35 +51,35 @@ where
     R: FailingStrategy,
 {
     fn is_lowercase(self) -> Self {
-        self.expecting(IsLowerCase)
+        self.expecting(is_lower_case())
     }
 
     fn is_uppercase(self) -> Self {
-        self.expecting(IsUpperCase)
+        self.expecting(is_upper_case())
     }
 
     fn is_ascii(self) -> Self {
-        self.expecting(IsAscii)
+        self.expecting(is_ascii())
     }
 
     fn is_alphabetic(self) -> Self {
-        self.expecting(IsAlphabetic)
+        self.expecting(is_alphabetic())
     }
 
     fn is_alphanumeric(self) -> Self {
-        self.expecting(IsAlphanumeric)
+        self.expecting(is_alphanumeric())
     }
 
     fn is_control_char(self) -> Self {
-        self.expecting(IsControlChar)
+        self.expecting(is_control_char())
     }
 
     fn is_digit(self, radix: u32) -> Self {
-        self.expecting(IsDigit { radix })
+        self.expecting(is_digit(radix))
     }
 
     fn is_whitespace(self) -> Self {
-        self.expecting(IsWhitespace)
+        self.expecting(is_whitespace())
     }
 }
 

--- a/src/char/tests.rs
+++ b/src/char/tests.rs
@@ -395,14 +395,14 @@ fn verify_borrowed_char_is_whitespace_fails() {
 proptest! {
     #[test]
     fn asserting_ascii_and_lowercase_is_equivalent_to_ascii_lowercase_method(
-        chr in prop::arbitrary::any::<char>(),
+        chr in any::<char>(),
     ) {
         prop_assert_eq!(chr.is_ascii() && chr.is_lowercase(), chr.is_ascii_lowercase());
     }
 
     #[test]
     fn asserting_ascii_and_uppercase_is_equivalent_to_ascii_uppercase_method(
-        chr in prop::arbitrary::any::<char>(),
+        chr in any::<char>(),
     ) {
         prop_assert_eq!(chr.is_ascii() && chr.is_uppercase(), chr.is_ascii_uppercase());
     }

--- a/src/char_count.rs
+++ b/src/char_count.rs
@@ -3,8 +3,9 @@
 use crate::assertions::AssertHasCharCount;
 use crate::colored::{mark_missing, mark_unexpected};
 use crate::expectations::{
-    HasAtLeastCharCount, HasAtMostCharCount, HasCharCount, HasCharCountGreaterThan,
-    HasCharCountInRange, HasCharCountLessThan,
+    has_at_least_char_count, has_at_most_char_count, has_char_count, has_char_count_greater_than,
+    has_char_count_in_range, has_char_count_less_than, HasAtLeastCharCount, HasAtMostCharCount,
+    HasCharCount, HasCharCountGreaterThan, HasCharCountInRange, HasCharCountLessThan,
 };
 use crate::properties::CharCountProperty;
 use crate::spec::{DiffFormat, Expectation, Expression, FailingStrategy, Spec};
@@ -19,40 +20,30 @@ where
     R: FailingStrategy,
 {
     fn has_char_count(self, expected_char_count: usize) -> Self {
-        self.expecting(HasCharCount {
-            expected_char_count,
-        })
+        self.expecting(has_char_count(expected_char_count))
     }
 
     fn has_char_count_in_range<U>(self, expected_range: U) -> Self
     where
         U: RangeBounds<usize> + Debug,
     {
-        self.expecting(HasCharCountInRange::new(expected_range))
+        self.expecting(has_char_count_in_range(expected_range))
     }
 
     fn has_char_count_less_than(self, expected_char_count: usize) -> Self {
-        self.expecting(HasCharCountLessThan {
-            expected_char_count,
-        })
+        self.expecting(has_char_count_less_than(expected_char_count))
     }
 
     fn has_char_count_greater_than(self, expected_char_count: usize) -> Self {
-        self.expecting(HasCharCountGreaterThan {
-            expected_char_count,
-        })
+        self.expecting(has_char_count_greater_than(expected_char_count))
     }
 
     fn has_at_most_char_count(self, expected_char_count: usize) -> Self {
-        self.expecting(HasAtMostCharCount {
-            expected_char_count,
-        })
+        self.expecting(has_at_most_char_count(expected_char_count))
     }
 
     fn has_at_least_char_count(self, expected_char_count: usize) -> Self {
-        self.expecting(HasAtLeastCharCount {
-            expected_char_count,
-        })
+        self.expecting(has_at_least_char_count(expected_char_count))
     }
 }
 

--- a/src/equality.rs
+++ b/src/equality.rs
@@ -2,7 +2,7 @@
 
 use crate::assertions::AssertEquality;
 use crate::colored::mark_diff;
-use crate::expectations::{IsEqualTo, Not};
+use crate::expectations::{is_equal_to, not, IsEqualTo};
 use crate::spec::{DiffFormat, Expectation, Expression, FailingStrategy, Invertible, Spec};
 use crate::std::fmt::Debug;
 use crate::std::{format, string::String};
@@ -14,11 +14,11 @@ where
     R: FailingStrategy,
 {
     fn is_equal_to(self, expected: E) -> Self {
-        self.expecting(IsEqualTo { expected })
+        self.expecting(is_equal_to(expected))
     }
 
     fn is_not_equal_to(self, expected: E) -> Self {
-        self.expecting(Not(IsEqualTo { expected }))
+        self.expecting(not(is_equal_to(expected)))
     }
 }
 

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,6 +1,8 @@
 use crate::assertions::AssertErrorHasSource;
 use crate::colored::{mark_missing, mark_missing_string, mark_unexpected, mark_unexpected_string};
-use crate::expectations::{ErrorHasSource, ErrorHasSourceMessage, Not};
+use crate::expectations::{
+    error_has_source, error_has_source_message, not, ErrorHasSource, ErrorHasSourceMessage,
+};
 use crate::spec::{DiffFormat, Expectation, Expression, FailingStrategy, Invertible, Spec};
 use crate::std::error::Error;
 use crate::std::format;
@@ -12,11 +14,11 @@ where
     R: FailingStrategy,
 {
     fn has_no_source(self) -> Self {
-        self.expecting(Not(ErrorHasSource))
+        self.expecting(not(error_has_source()))
     }
 
     fn has_source(self) -> Self {
-        self.expecting(ErrorHasSource)
+        self.expecting(error_has_source())
     }
 
     fn has_source_message(
@@ -24,10 +26,8 @@ where
         expected_source_message: impl Into<String>,
     ) -> Spec<'a, Option<String>, R> {
         let expected_source_message = expected_source_message.into();
-        self.expecting(ErrorHasSourceMessage {
-            expected_source_message,
-        })
-        .mapping(|err| err.source().map(ToString::to_string))
+        self.expecting(error_has_source_message(expected_source_message))
+            .mapping(|err| err.source().map(ToString::to_string))
     }
 }
 

--- a/src/expectation_combinators/tests.rs
+++ b/src/expectation_combinators/tests.rs
@@ -1,6 +1,6 @@
 use crate::expectations::{
-    IsBetween, IsEmpty, IsGreaterThan, IsLessThan, IsNegative, IsOne, IsPositive, IsZero,
-    StringContains, StringContainsAnyOf,
+    all, any, not, rec, IsBetween, IsEmpty, IsGreaterThan, IsLessThan, IsNegative, IsOne,
+    IsPositive, IsZero, StringContains, StringContainsAnyOf,
 };
 use crate::prelude::*;
 use crate::spec::{Expectation, Expression};

--- a/src/expectations.rs
+++ b/src/expectations.rs
@@ -6,13 +6,15 @@
 use crate::std::marker::PhantomData;
 use crate::std::{string::String, vec::Vec};
 use hashbrown::HashSet;
+#[cfg(feature = "regex")]
+use regex::Regex;
 
 /// Creates a [`Not`] expectation combinator wrapping the given expectation.
 ///
 /// # Examples
 ///
 /// ```
-/// use asserting::expectations::{HasLength, IsEmpty, IsEqualTo, IsNegative, StringContains};
+/// use asserting::expectations::{not, HasLength, IsEmpty, IsEqualTo, IsNegative, StringContains};
 /// use asserting::prelude::*;
 ///
 /// assert_that!(41).expecting(not(IsEqualTo { expected: 42 }));
@@ -46,12 +48,12 @@ pub struct Not<E>(pub E);
 /// # Examples
 ///
 /// ```
-/// use asserting::expectations::{IsAtMost, IsPositive};
+/// use asserting::expectations::{all, IsAtMost, IsPositive};
 /// use asserting::prelude::*;
 ///
 /// let custom_expectation = all((IsPositive, IsAtMost { expected: 99 }));
 ///
-/// assert_that(42).expecting(custom_expectation);  
+/// assert_that!(42).expecting(custom_expectation);
 /// ```
 pub fn all<A>(expectations: A) -> All<A::Output>
 where
@@ -68,24 +70,17 @@ where
 #[must_use]
 pub struct All<E>(pub E);
 
-/// Creates a [`Rec`] expectation combinator that wraps the given expectation.
-///
-/// This is a convenience function that is equivalent to `Rec::new()`.
-pub fn rec<E>(expectations: E) -> Rec<E> {
-    Rec::new(expectations)
-}
-
 /// Creates an [`Any`] expectation combinator from a tuple of expectations.
 ///
 /// # Examples
 ///
 /// ```
-/// use asserting::expectations::{IsEmpty, StringContains};
+/// use asserting::expectations::{any, not, IsEmpty, StringContains};
 /// use asserting::prelude::*;
 ///
 /// let custom_expectation = any((not(IsEmpty), StringContains { expected: "unfugiaty" }));
 ///
-/// assert_that("elit fugiat dolores").expecting(custom_expectation);
+/// assert_that!("elit fugiat dolores").expecting(custom_expectation);
 /// ```
 pub fn any<A>(expectations: A) -> Any<A::Output>
 where
@@ -100,6 +95,13 @@ where
 /// Use the function [`any()`] to construct an `Any` combinator for a tuple of
 /// expectations.
 pub struct Any<E>(pub E);
+
+/// Creates a [`Rec`] expectation combinator that wraps the given expectation.
+///
+/// This is a convenience function that is equivalent to `Rec::new()`.
+pub fn rec<E>(expectations: E) -> Rec<E> {
+    Rec::new(expectations)
+}
 
 /// A combinator expectation that memorizes ("records") the result of the
 /// wrapped expectation.
@@ -116,20 +118,20 @@ pub struct Any<E>(pub E);
 ///
 /// // the result of new `Rec` is neither `success` nor `failure`
 /// let mut expectation = rec(IsNegative);
-/// assert_that(expectation.is_failure()).is_false();
-/// assert_that(expectation.is_success()).is_false();
+/// assert_that!(expectation.is_failure()).is_false();
+/// assert_that!(expectation.is_success()).is_false();
 ///
 /// // once the `test` method has been called, the result can be queried at a
 /// // later time.
 /// _ = expectation.test(&-42);  // returns true
-/// assert_that(expectation.is_success()).is_true();
-/// assert_that(expectation.is_failure()).is_false();
+/// assert_that!(expectation.is_success()).is_true();
+/// assert_that!(expectation.is_failure()).is_false();
 ///
 /// // once the `test` method has been called, the result can be queried at a
 /// // later time.
 /// _= expectation.test(&42);  // returns false
-/// assert_that(expectation.is_success()).is_false();
-/// assert_that(expectation.is_failure()).is_true();
+/// assert_that!(expectation.is_success()).is_false();
+/// assert_that!(expectation.is_failure()).is_true();
 /// ```
 #[must_use]
 pub struct Rec<E> {
@@ -177,21 +179,108 @@ pub trait IntoRec {
     fn into_rec(self) -> Self::Output;
 }
 
+/// Creates a [`Predicate`] expectation from a predicate function.
+///
+/// The failure message will contain a generic description of the expectation.
+/// To specify a custom description for the expectation, use the method [`Predicate::with_message`]
+/// on the newly constructed expectation.
+///
+/// # Examples
+///
+/// ```
+/// use asserting::expectations::satisfies;
+/// use asserting::prelude::*;
+///
+/// fn is_odd(number: &i32) -> bool {
+///     *number & 1 == 1
+/// }
+///
+/// // with a generic description
+/// assert_that!(5).expecting(satisfies(is_odd));
+///
+/// // with a custom description
+/// assert_that!(5).expecting(
+///     satisfies(is_odd).with_message("my number to be odd")
+/// );
+/// ```
+pub fn satisfies<F>(predicate: F) -> Predicate<F> {
+    Predicate {
+        predicate,
+        message: None,
+    }
+}
+
 #[must_use]
 pub struct Predicate<F> {
     pub predicate: F,
     pub message: Option<String>,
 }
 
+impl<F> Predicate<F> {
+    /// Sets a custom description of the expectation.
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
+    }
+}
+
+/// Creates an [`IsTrue`] expectation.
+pub fn is_true() -> IsTrue {
+    IsTrue
+}
+
 #[must_use]
 pub struct IsTrue;
+
+/// Creates a [`IsFalse`] expectation.
+pub fn is_false() -> IsFalse {
+    IsFalse
+}
 
 #[must_use]
 pub struct IsFalse;
 
+/// Creates an [`IsEqualTo`] expectation.
+pub fn is_equal_to<E>(expected: E) -> IsEqualTo<E> {
+    IsEqualTo { expected }
+}
+
 #[must_use]
 pub struct IsEqualTo<E> {
     pub expected: E,
+}
+
+/// Creates an [`IsCloseTo`] expectation.
+///
+/// The margin is set to a default value. To define a custom margin, use the
+/// method [`IsCloseTo::within_margin`] on the newly constructed expectation.
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(not(feature = "float-cmp"))]
+/// # fn main() {}
+/// # #[cfg(feature = "float-cmp")]
+/// # fn main() {
+/// use asserting::expectations::is_close_to;
+/// use asserting::prelude::*;
+///
+/// // using the default margin
+/// assert_that!(-2.453).expecting(is_close_to(-2.453));
+///
+/// // with custom margin
+/// assert_that!(-2.453_f32)
+///     .expecting(is_close_to(-2.453).within_margin((0.001, 4)));
+/// # }
+/// ```
+pub fn is_close_to<E, M>(expected: E) -> IsCloseTo<E, M>
+where
+    M: Default,
+{
+    IsCloseTo {
+        expected,
+        margin: M::default(),
+    }
 }
 
 #[must_use]
@@ -204,6 +293,7 @@ impl<E, M> IsCloseTo<E, M>
 where
     M: Default,
 {
+    #[deprecated = "use the function [`is_close_to`] instead"]
     pub fn new(expected: E) -> Self {
         Self {
             expected,
@@ -219,9 +309,19 @@ impl<E, M> IsCloseTo<E, M> {
     }
 }
 
+/// Creates an [`IsLessThan`] expectation.
+pub fn is_less_than<E>(expected: E) -> IsLessThan<E> {
+    IsLessThan { expected }
+}
+
 #[must_use]
 pub struct IsLessThan<E> {
     pub expected: E,
+}
+
+/// Creates an [`IsAtMost`] expectation.
+pub fn is_at_most<E>(expected: E) -> IsAtMost<E> {
+    IsAtMost { expected }
 }
 
 #[must_use]
@@ -229,9 +329,19 @@ pub struct IsAtMost<E> {
     pub expected: E,
 }
 
+/// Creates an [`IsGreaterThan`] expectation.
+pub fn is_greater_than<E>(expected: E) -> IsGreaterThan<E> {
+    IsGreaterThan { expected }
+}
+
 #[must_use]
 pub struct IsGreaterThan<E> {
     pub expected: E,
+}
+
+/// Creates an [`IsAtLeast`] expectation.
+pub fn is_at_least<E>(expected: E) -> IsAtLeast<E> {
+    IsAtLeast { expected }
 }
 
 #[must_use]
@@ -239,9 +349,19 @@ pub struct IsAtLeast<E> {
     pub expected: E,
 }
 
+/// Creates an [`IsBefore`] expectation.
+pub fn is_before<E>(expected: E) -> IsBefore<E> {
+    IsBefore { expected }
+}
+
 #[must_use]
 pub struct IsBefore<E> {
     pub expected: E,
+}
+
+/// Creates an [`IsAfter`] expectation.
+pub fn is_after<E>(expected: E) -> IsAfter<E> {
+    IsAfter { expected }
 }
 
 #[must_use]
@@ -249,10 +369,23 @@ pub struct IsAfter<E> {
     pub expected: E,
 }
 
+/// Creates an [`IsBetween`] expectation.
+pub fn is_between<E>(min: E, max: E) -> IsBetween<E> {
+    IsBetween { min, max }
+}
+
 #[must_use]
 pub struct IsBetween<E> {
     pub min: E,
     pub max: E,
+}
+
+/// Creates an [`IsInRange`] expectation.
+pub fn is_in_range<R, E>(expected_range: R) -> IsInRange<R, E> {
+    IsInRange {
+        expected_range,
+        _element_type: PhantomData,
+    }
 }
 
 #[must_use]
@@ -262,6 +395,7 @@ pub struct IsInRange<R, E> {
 }
 
 impl<R, E> IsInRange<R, E> {
+    #[deprecated = "use the function [`is_in_range`] instead"]
     pub fn new(expected_range: R) -> Self {
         Self {
             expected_range,
@@ -270,30 +404,75 @@ impl<R, E> IsInRange<R, E> {
     }
 }
 
+/// Creates an [`IsNegative`] expectation.
+pub fn is_negative() -> IsNegative {
+    IsNegative
+}
+
 #[must_use]
 pub struct IsNegative;
+
+/// Creates an [`IsPositive`] expectation.
+pub fn is_positive() -> IsPositive {
+    IsPositive
+}
 
 #[must_use]
 pub struct IsPositive;
 
+/// Creates an [`IsZero`] expectation.
+pub fn is_zero() -> IsZero {
+    IsZero
+}
+
 #[must_use]
 pub struct IsZero;
+
+/// Creates an [`IsOne`] expectation.
+pub fn is_one() -> IsOne {
+    IsOne
+}
 
 #[must_use]
 pub struct IsOne;
 
+/// Creates an [`IsFinite`] expectation.
+pub fn is_finite() -> IsFinite {
+    IsFinite
+}
+
 #[must_use]
 pub struct IsFinite;
+
+/// Creates an [`IsInfinite`] expectation.
+pub fn is_infinite() -> IsInfinite {
+    IsInfinite
+}
 
 #[must_use]
 pub struct IsInfinite;
 
+/// Creates an [`IsANumber`] expectation.
+pub fn is_a_number() -> IsANumber {
+    IsANumber
+}
+
 #[must_use]
 pub struct IsANumber;
+
+/// Creates a [`HasPrecisionOf`] expectation.
+pub fn has_precision_of(expected_precision: u64) -> HasPrecisionOf {
+    HasPrecisionOf { expected_precision }
+}
 
 #[must_use]
 pub struct HasPrecisionOf {
     pub expected_precision: u64,
+}
+
+/// Creates a [`HasScaleOf`] expectation.
+pub fn has_scale_of(expected_scale: i64) -> HasScaleOf {
+    HasScaleOf { expected_scale }
 }
 
 #[must_use]
@@ -301,71 +480,178 @@ pub struct HasScaleOf {
     pub expected_scale: i64,
 }
 
+/// Creates an [`IsInteger`] expectation.
+pub fn is_integer() -> IsInteger {
+    IsInteger
+}
+
 #[must_use]
 pub struct IsInteger;
+
+/// Creates an [`IsLowerCase`] expectation.
+pub fn is_lower_case() -> IsLowerCase {
+    IsLowerCase
+}
 
 #[must_use]
 pub struct IsLowerCase;
 
+/// Creates an [`IsUpperCase`] expectation.
+pub fn is_upper_case() -> IsUpperCase {
+    IsUpperCase
+}
+
 #[must_use]
 pub struct IsUpperCase;
+
+/// Creates an [`IsAscii`] expectation.
+pub fn is_ascii() -> IsAscii {
+    IsAscii
+}
 
 #[must_use]
 pub struct IsAscii;
 
+/// Creates an [`IsAlphabetic`] expectation.
+pub fn is_alphabetic() -> IsAlphabetic {
+    IsAlphabetic
+}
+
 #[must_use]
 pub struct IsAlphabetic;
+
+/// Creates an [`IsAlphanumeric`] expectation.
+pub fn is_alphanumeric() -> IsAlphanumeric {
+    IsAlphanumeric
+}
 
 #[must_use]
 pub struct IsAlphanumeric;
 
+/// Creates an [`IsControlChar`] expectation.
+pub fn is_control_char() -> IsControlChar {
+    IsControlChar
+}
+
 #[must_use]
 pub struct IsControlChar;
+
+/// Creates an [`IsDigit`] expectation.
+pub fn is_digit(radix: u32) -> IsDigit {
+    IsDigit { radix }
+}
 
 #[must_use]
 pub struct IsDigit {
     pub radix: u32,
 }
 
+/// Creates an [`IsWhitespace`] expectation.
+pub fn is_whitespace() -> IsWhitespace {
+    IsWhitespace
+}
+
 #[must_use]
 pub struct IsWhitespace;
+
+/// Creates an [`IsSome`] expectation.
+pub fn is_some() -> IsSome {
+    IsSome
+}
 
 #[must_use]
 pub struct IsSome;
 
+/// Creates an [`IsNone`] expectation.
+pub fn is_none() -> IsNone {
+    IsNone
+}
+
 #[must_use]
 pub struct IsNone;
+
+/// Creates a [`HasValue`] expectation.
+pub fn has_value<E>(expected: E) -> HasValue<E> {
+    HasValue { expected }
+}
 
 #[must_use]
 pub struct HasValue<E> {
     pub expected: E,
 }
 
+/// Creates an [`IsOk`] expectation.
+pub fn is_ok() -> IsOk {
+    IsOk
+}
+
 #[must_use]
 pub struct IsOk;
 
+/// Creates an [`IsErr`] expectation.
+pub fn is_err() -> IsErr {
+    IsErr
+}
+
 #[must_use]
 pub struct IsErr;
+
+/// Creates a [`HasError`] expectation.
+pub fn has_error<E>(expected: E) -> HasError<E> {
+    HasError { expected }
+}
 
 #[must_use]
 pub struct HasError<E> {
     pub expected: E,
 }
 
+/// Creates an [`ErrorHasSource`] expectation.
+pub fn error_has_source() -> ErrorHasSource {
+    ErrorHasSource
+}
+
 #[must_use]
 pub struct ErrorHasSource;
+
+/// Creates an [`ErrorHasSourceMessage`] expectation.
+pub fn error_has_source_message(
+    expected_source_message: impl Into<String>,
+) -> ErrorHasSourceMessage {
+    ErrorHasSourceMessage {
+        expected_source_message: expected_source_message.into(),
+    }
+}
 
 #[must_use]
 pub struct ErrorHasSourceMessage {
     pub expected_source_message: String,
 }
 
+/// Creates an [`IsEmpty`] expectation.
+pub fn is_empty() -> IsEmpty {
+    IsEmpty
+}
+
 #[must_use]
 pub struct IsEmpty;
+
+/// Creates a [`HasLength`] expectation.
+pub fn has_length<E>(expected_length: E) -> HasLength<E> {
+    HasLength { expected_length }
+}
 
 #[must_use]
 pub struct HasLength<E> {
     pub expected_length: E,
+}
+
+/// Creates a [`HasLengthInRange`] expectation.
+pub fn has_length_in_range<R, E>(expected_range: R) -> HasLengthInRange<R, E> {
+    HasLengthInRange {
+        expected_range,
+        _element_type: PhantomData,
+    }
 }
 
 #[must_use]
@@ -375,6 +661,7 @@ pub struct HasLengthInRange<R, E> {
 }
 
 impl<R, E> HasLengthInRange<R, E> {
+    #[deprecated = "use the function [`has_length_in_range`] instead"]
     pub fn new(expected_range: R) -> Self {
         Self {
             expected_range,
@@ -383,9 +670,19 @@ impl<R, E> HasLengthInRange<R, E> {
     }
 }
 
+/// Creates a [`HasLengthLessThan`] expectation.
+pub fn has_length_less_than<E>(expected_length: E) -> HasLengthLessThan<E> {
+    HasLengthLessThan { expected_length }
+}
+
 #[must_use]
 pub struct HasLengthLessThan<E> {
     pub expected_length: E,
+}
+
+/// Creates a [`HasLengthGreaterThan`] expectation.
+pub fn has_length_greater_than<E>(expected_length: E) -> HasLengthGreaterThan<E> {
+    HasLengthGreaterThan { expected_length }
 }
 
 #[must_use]
@@ -393,9 +690,19 @@ pub struct HasLengthGreaterThan<E> {
     pub expected_length: E,
 }
 
+/// Creates a [`HasAtMostLength`] expectation.
+pub fn has_at_most_length<E>(expected_length: E) -> HasAtMostLength<E> {
+    HasAtMostLength { expected_length }
+}
+
 #[must_use]
 pub struct HasAtMostLength<E> {
     pub expected_length: E,
+}
+
+/// Creates a [`HasAtLeastLength`] expectation.
+pub fn has_at_least_length<E>(expected_length: E) -> HasAtLeastLength<E> {
+    HasAtLeastLength { expected_length }
 }
 
 #[must_use]
@@ -403,9 +710,24 @@ pub struct HasAtLeastLength<E> {
     pub expected_length: E,
 }
 
+/// Creates a [`HasCharCount`] expectation.
+pub fn has_char_count<E>(expected_char_count: E) -> HasCharCount<E> {
+    HasCharCount {
+        expected_char_count,
+    }
+}
+
 #[must_use]
 pub struct HasCharCount<E> {
     pub expected_char_count: E,
+}
+
+/// Creates a [`HasCharCountInRange`] expectation.
+pub fn has_char_count_in_range<R, E>(expected_range: R) -> HasCharCountInRange<R, E> {
+    HasCharCountInRange {
+        expected_range,
+        _element_type: PhantomData,
+    }
 }
 
 #[must_use]
@@ -415,6 +737,7 @@ pub struct HasCharCountInRange<R, E> {
 }
 
 impl<R, E> HasCharCountInRange<R, E> {
+    #[deprecated = "use the function [`has_char_count_in_range`] instead"]
     pub fn new(expected_range: R) -> Self {
         Self {
             expected_range,
@@ -423,9 +746,23 @@ impl<R, E> HasCharCountInRange<R, E> {
     }
 }
 
+/// Creates a [`HasCharCountLessThan`] expectation.
+pub fn has_char_count_less_than<E>(expected_char_count: E) -> HasCharCountLessThan<E> {
+    HasCharCountLessThan {
+        expected_char_count,
+    }
+}
+
 #[must_use]
 pub struct HasCharCountLessThan<E> {
     pub expected_char_count: E,
+}
+
+/// Creates a [`HasCharCount`] expectation.
+pub fn has_char_count_greater_than<E>(expected_char_count: E) -> HasCharCountGreaterThan<E> {
+    HasCharCountGreaterThan {
+        expected_char_count,
+    }
 }
 
 #[must_use]
@@ -433,9 +770,23 @@ pub struct HasCharCountGreaterThan<E> {
     pub expected_char_count: E,
 }
 
+/// Creates a [`HasAtMostCharCount`] expectation.
+pub fn has_at_most_char_count<E>(expected_char_count: E) -> HasAtMostCharCount<E> {
+    HasAtMostCharCount {
+        expected_char_count,
+    }
+}
+
 #[must_use]
 pub struct HasAtMostCharCount<E> {
     pub expected_char_count: E,
+}
+
+/// Creates a [`HasAtLeastCharCount`] expectation.
+pub fn has_at_least_char_count<E>(expected_char_count: E) -> HasAtLeastCharCount<E> {
+    HasAtLeastCharCount {
+        expected_char_count,
+    }
 }
 
 #[must_use]
@@ -443,9 +794,19 @@ pub struct HasAtLeastCharCount<E> {
     pub expected_char_count: E,
 }
 
+/// Creates a [`StringContains`] expectation.
+pub fn string_contains<E>(expected: E) -> StringContains<E> {
+    StringContains { expected }
+}
+
 #[must_use]
 pub struct StringContains<E> {
     pub expected: E,
+}
+
+/// Creates a [`StringContainsAnyOf`] expectation.
+pub fn string_contains_any_of<E>(expected: E) -> StringContainsAnyOf<E> {
+    StringContainsAnyOf { expected }
 }
 
 #[must_use]
@@ -453,9 +814,19 @@ pub struct StringContainsAnyOf<E> {
     pub expected: E,
 }
 
+/// Creates a [`StringStartWith`] expectation.
+pub fn string_starts_with<E>(expected: E) -> StringStartWith<E> {
+    StringStartWith { expected }
+}
+
 #[must_use]
 pub struct StringStartWith<E> {
     pub expected: E,
+}
+
+/// Creates a [`StringEndsWith`] expectation.
+pub fn string_ends_with<E>(expected: E) -> StringEndsWith<E> {
+    StringEndsWith { expected }
 }
 
 #[must_use]
@@ -463,50 +834,79 @@ pub struct StringEndsWith<E> {
     pub expected: E,
 }
 
+/// Creates a [`StringMatches`] expectation.
+///
+/// # Panics
+///
+/// Panics, if the regex pattern is invalid or exceeds the size limit.
 #[cfg(feature = "regex")]
 #[cfg_attr(docsrs, doc(cfg(feature = "regex")))]
-pub use regex::StringMatches;
+pub fn string_matches(regex_pattern: &str) -> StringMatches<'_> {
+    let regex = Regex::new(regex_pattern)
+        .unwrap_or_else(|err| panic!("failed to match string with regex: {err}"));
+    StringMatches {
+        pattern: regex_pattern,
+        regex,
+    }
+}
 
 #[cfg(feature = "regex")]
-mod regex {
-    use regex::Regex;
+#[cfg_attr(docsrs, doc(cfg(feature = "regex")))]
+#[must_use]
+pub struct StringMatches<'a> {
+    pub pattern: &'a str,
+    pub regex: Regex,
+}
 
-    #[must_use]
-    pub struct StringMatches<'a> {
-        pub pattern: &'a str,
-        pub regex: Regex,
-    }
-
-    impl<'a> StringMatches<'a> {
-        /// Creates a new `StringMatches`-expectation.
-        ///
-        /// # Panics
-        ///
-        /// Panics, if the regex pattern is invalid or exceeds the size limit.
-        pub fn new(regex_pattern: &'a str) -> Self {
-            let regex = Regex::new(regex_pattern)
-                .unwrap_or_else(|err| panic!("failed to match string with regex: {err}"));
-            Self {
-                pattern: regex_pattern,
-                regex,
-            }
+#[cfg(feature = "regex")]
+#[cfg_attr(docsrs, doc(cfg(feature = "regex")))]
+impl<'a> StringMatches<'a> {
+    /// Creates a new `StringMatches`-expectation.
+    ///
+    /// # Panics
+    ///
+    /// Panics, if the regex pattern is invalid or exceeds the size limit.
+    #[deprecated = "use the function [`string_matches`] instead"]
+    pub fn new(regex_pattern: &'a str) -> Self {
+        let regex = Regex::new(regex_pattern)
+            .unwrap_or_else(|err| panic!("failed to match string with regex: {err}"));
+        Self {
+            pattern: regex_pattern,
+            regex,
         }
     }
 }
 
+/// Creates an [`IteratorContains`] expectation.
+pub fn iterator_contains<E>(expected: E) -> IteratorContains<E> {
+    IteratorContains { expected }
+}
+
 #[must_use]
-pub struct IterContains<E> {
+pub struct IteratorContains<E> {
     pub expected: E,
 }
 
+/// Creates an [`IteratorContainsExactlyInAnyOrder`] expectation.
+pub fn iterator_contains_exactly_in_any_order<E>(
+    expected: impl IntoIterator<Item = E>,
+) -> IteratorContainsExactlyInAnyOrder<E> {
+    IteratorContainsExactlyInAnyOrder {
+        expected: Vec::from_iter(expected),
+        missing: HashSet::new(),
+        extra: HashSet::new(),
+    }
+}
+
 #[must_use]
-pub struct IterContainsExactlyInAnyOrder<E> {
+pub struct IteratorContainsExactlyInAnyOrder<E> {
     pub expected: Vec<E>,
     pub missing: HashSet<usize>,
     pub extra: HashSet<usize>,
 }
 
-impl<E> IterContainsExactlyInAnyOrder<E> {
+impl<E> IteratorContainsExactlyInAnyOrder<E> {
+    #[deprecated = "use the function [`iterator_contains_exactly_in_any_order`] instead"]
     pub fn new(expected: Vec<E>) -> Self {
         Self {
             expected,
@@ -516,18 +916,38 @@ impl<E> IterContainsExactlyInAnyOrder<E> {
     }
 }
 
-#[must_use]
-pub struct IterContainsAnyOf<E> {
-    pub expected: Vec<E>,
+/// Creates an [`IteratorContainsAnyOf`] expectation.
+pub fn iterator_contains_any_of<E>(
+    expected: impl IntoIterator<Item = E>,
+) -> IteratorContainsAnyOf<E> {
+    IteratorContainsAnyOf {
+        expected: Vec::from_iter(expected),
+    }
 }
 
 #[must_use]
-pub struct IterContainsAllOf<E> {
+pub struct IteratorContainsAnyOf<E> {
+    pub expected: Vec<E>,
+}
+
+/// Creates an [`IteratorContainsAllOf`] expectation.
+pub fn iterator_contains_all_of<E>(
+    expected: impl IntoIterator<Item = E>,
+) -> IteratorContainsAllOf<E> {
+    IteratorContainsAllOf {
+        expected: Vec::from_iter(expected),
+        missing: HashSet::new(),
+    }
+}
+
+#[must_use]
+pub struct IteratorContainsAllOf<E> {
     pub expected: Vec<E>,
     pub missing: HashSet<usize>,
 }
 
-impl<E> IterContainsAllOf<E> {
+impl<E> IteratorContainsAllOf<E> {
+    #[deprecated = "use the function [`iterator_contains_all_of`] instead"]
     pub fn new(expected: Vec<E>) -> Self {
         Self {
             expected,
@@ -536,13 +956,22 @@ impl<E> IterContainsAllOf<E> {
     }
 }
 
+/// Creates an [`IteratorContainsOnly`] expectation.
+pub fn iterator_contains_only<E>(expected: impl IntoIterator<Item = E>) -> IteratorContainsOnly<E> {
+    IteratorContainsOnly {
+        expected: Vec::from_iter(expected),
+        extra: HashSet::new(),
+    }
+}
+
 #[must_use]
-pub struct IterContainsOnly<E> {
+pub struct IteratorContainsOnly<E> {
     pub expected: Vec<E>,
     pub extra: HashSet<usize>,
 }
 
-impl<E> IterContainsOnly<E> {
+impl<E> IteratorContainsOnly<E> {
+    #[deprecated = "use the function [`iterator_contains_only`] instead"]
     pub fn new(expected: Vec<E>) -> Self {
         Self {
             expected,
@@ -551,14 +980,26 @@ impl<E> IterContainsOnly<E> {
     }
 }
 
+/// Creates an [`IteratorContainsOnlyOnce`] expectation.
+pub fn iterator_contains_only_once<E>(
+    expected: impl IntoIterator<Item = E>,
+) -> IteratorContainsOnlyOnce<E> {
+    IteratorContainsOnlyOnce {
+        expected: Vec::from_iter(expected),
+        extra: HashSet::new(),
+        duplicates: HashSet::new(),
+    }
+}
+
 #[must_use]
-pub struct IterContainsOnlyOnce<E> {
+pub struct IteratorContainsOnlyOnce<E> {
     pub expected: Vec<E>,
     pub extra: HashSet<usize>,
     pub duplicates: HashSet<usize>,
 }
 
-impl<E> IterContainsOnlyOnce<E> {
+impl<E> IteratorContainsOnlyOnce<E> {
+    #[deprecated = "use the function [`iterator_contains_only_once`] instead"]
     pub fn new(expected: Vec<E>) -> Self {
         Self {
             expected,
@@ -568,15 +1009,28 @@ impl<E> IterContainsOnlyOnce<E> {
     }
 }
 
+/// Creates an [`IteratorContainsExactly`] expectation.
+pub fn iterator_contains_exactly<E>(
+    expected: impl IntoIterator<Item = E>,
+) -> IteratorContainsExactly<E> {
+    IteratorContainsExactly {
+        expected: Vec::from_iter(expected),
+        missing: HashSet::new(),
+        extra: HashSet::new(),
+        out_of_order: HashSet::new(),
+    }
+}
+
 #[must_use]
-pub struct IterContainsExactly<E> {
+pub struct IteratorContainsExactly<E> {
     pub expected: Vec<E>,
     pub missing: HashSet<usize>,
     pub extra: HashSet<usize>,
     pub out_of_order: HashSet<usize>,
 }
 
-impl<E> IterContainsExactly<E> {
+impl<E> IteratorContainsExactly<E> {
+    #[deprecated = "use the function [`iterator_contains_exactly`] instead"]
     pub fn new(expected: Vec<E>) -> Self {
         Self {
             expected,
@@ -587,14 +1041,26 @@ impl<E> IterContainsExactly<E> {
     }
 }
 
+/// Creates an [`IteratorContainsAnyOf`] expectation.
+pub fn iterator_contains_sequence<E>(
+    expected: impl IntoIterator<Item = E>,
+) -> IteratorContainsSequence<E> {
+    IteratorContainsSequence {
+        expected: Vec::from_iter(expected),
+        missing: HashSet::new(),
+        extra: HashSet::new(),
+    }
+}
+
 #[must_use]
-pub struct IterContainsSequence<E> {
+pub struct IteratorContainsSequence<E> {
     pub expected: Vec<E>,
     pub missing: HashSet<usize>,
     pub extra: HashSet<usize>,
 }
 
-impl<E> IterContainsSequence<E> {
+impl<E> IteratorContainsSequence<E> {
+    #[deprecated = "use the function [`iterator_contains_sequence`] instead"]
     pub fn new(expected: Vec<E>) -> Self {
         Self {
             expected,
@@ -604,13 +1070,24 @@ impl<E> IterContainsSequence<E> {
     }
 }
 
+/// Creates an [`IteratorContainsAllInOrder`] expectation.
+pub fn iterator_contains_all_in_order<E>(
+    expected: impl IntoIterator<Item = E>,
+) -> IteratorContainsAllInOrder<E> {
+    IteratorContainsAllInOrder {
+        expected: Vec::from_iter(expected),
+        missing: HashSet::new(),
+    }
+}
+
 #[must_use]
-pub struct IterContainsAllInOrder<E> {
+pub struct IteratorContainsAllInOrder<E> {
     pub expected: Vec<E>,
     pub missing: HashSet<usize>,
 }
 
-impl<E> IterContainsAllInOrder<E> {
+impl<E> IteratorContainsAllInOrder<E> {
+    #[deprecated = "use the function [`iterator_contains_all_in_order`] instead"]
     pub fn new(expected: Vec<E>) -> Self {
         Self {
             expected,
@@ -619,14 +1096,24 @@ impl<E> IterContainsAllInOrder<E> {
     }
 }
 
+/// Creates an [`IteratorStartsWith`] expectation.
+pub fn iterator_starts_with<E>(expected: impl IntoIterator<Item = E>) -> IteratorStartsWith<E> {
+    IteratorStartsWith {
+        expected: Vec::from_iter(expected),
+        missing: HashSet::new(),
+        extra: HashSet::new(),
+    }
+}
+
 #[must_use]
-pub struct IterStartsWith<E> {
+pub struct IteratorStartsWith<E> {
     pub expected: Vec<E>,
     pub missing: HashSet<usize>,
     pub extra: HashSet<usize>,
 }
 
-impl<E> IterStartsWith<E> {
+impl<E> IteratorStartsWith<E> {
+    #[deprecated = "use the function [`iterator_starts_with`] instead"]
     pub fn new(expected: Vec<E>) -> Self {
         Self {
             expected,
@@ -636,14 +1123,24 @@ impl<E> IterStartsWith<E> {
     }
 }
 
+/// Creates an [`IteratorEndsWith`] expectation.
+pub fn iterator_ends_with<E>(expected: impl IntoIterator<Item = E>) -> IteratorEndsWith<E> {
+    IteratorEndsWith {
+        expected: Vec::from_iter(expected),
+        missing: HashSet::new(),
+        extra: HashSet::new(),
+    }
+}
+
 #[must_use]
-pub struct IterEndsWith<E> {
+pub struct IteratorEndsWith<E> {
     pub expected: Vec<E>,
     pub missing: HashSet<usize>,
     pub extra: HashSet<usize>,
 }
 
-impl<E> IterEndsWith<E> {
+impl<E> IteratorEndsWith<E> {
+    #[deprecated = "use the function [`iterator_ends_with`] instead"]
     pub fn new(expected: Vec<E>) -> Self {
         Self {
             expected,
@@ -651,6 +1148,11 @@ impl<E> IterEndsWith<E> {
             extra: HashSet::new(),
         }
     }
+}
+
+/// Creates a [`MapContainsKey`] expectation.
+pub fn map_contains_key<E>(expected_key: E) -> MapContainsKey<E> {
+    MapContainsKey { expected_key }
 }
 
 #[must_use]
@@ -658,9 +1160,22 @@ pub struct MapContainsKey<E> {
     pub expected_key: E,
 }
 
+/// Creates a [`MapContainsValue`] expectation.
+pub fn map_contains_value<E>(expected_value: E) -> MapContainsValue<E> {
+    MapContainsValue { expected_value }
+}
+
 #[must_use]
 pub struct MapContainsValue<E> {
     pub expected_value: E,
+}
+
+/// Creates a [`MapContainsKeys`] expectation.
+pub fn map_contains_keys<E>(expected_keys: impl IntoIterator<Item = E>) -> MapContainsKeys<E> {
+    MapContainsKeys {
+        expected_keys: Vec::from_iter(expected_keys),
+        missing: HashSet::new(),
+    }
 }
 
 #[must_use]
@@ -670,11 +1185,22 @@ pub struct MapContainsKeys<E> {
 }
 
 impl<E> MapContainsKeys<E> {
+    #[deprecated = "use the function [`map_contains_keys`] instead"]
     pub fn new(expected_keys: impl IntoIterator<Item = E>) -> Self {
         Self {
             expected_keys: Vec::from_iter(expected_keys),
             missing: HashSet::new(),
         }
+    }
+}
+
+/// Creates a [`MapDoesNotContainKeys`] expectation.
+pub fn map_does_not_contain_keys<E>(
+    expected_keys: impl IntoIterator<Item = E>,
+) -> MapDoesNotContainKeys<E> {
+    MapDoesNotContainKeys {
+        expected_keys: Vec::from_iter(expected_keys),
+        extra: HashSet::new(),
     }
 }
 
@@ -685,11 +1211,22 @@ pub struct MapDoesNotContainKeys<E> {
 }
 
 impl<E> MapDoesNotContainKeys<E> {
+    #[deprecated = "use the function [`map_does_not_contain_keys`] instead"]
     pub fn new(expected_keys: impl IntoIterator<Item = E>) -> Self {
         Self {
             expected_keys: Vec::from_iter(expected_keys),
             extra: HashSet::new(),
         }
+    }
+}
+
+/// Creates a [`MapContainsValues`] expectation.
+pub fn map_contains_values<E>(
+    expected_values: impl IntoIterator<Item = E>,
+) -> MapContainsValues<E> {
+    MapContainsValues {
+        expected_values: Vec::from_iter(expected_values),
+        missing: HashSet::new(),
     }
 }
 
@@ -700,11 +1237,22 @@ pub struct MapContainsValues<E> {
 }
 
 impl<E> MapContainsValues<E> {
+    #[deprecated = "use the function [`map_contains_values`] instead"]
     pub fn new(expected_values: impl IntoIterator<Item = E>) -> Self {
         Self {
             expected_values: Vec::from_iter(expected_values),
             missing: HashSet::new(),
         }
+    }
+}
+
+/// Creates a [`MapDoesNotContainValues`] expectation.
+pub fn map_does_not_contain_values<E>(
+    expected_values: impl IntoIterator<Item = E>,
+) -> MapDoesNotContainValues<E> {
+    MapDoesNotContainValues {
+        expected_values: Vec::from_iter(expected_values),
+        extra: HashSet::new(),
     }
 }
 
@@ -715,11 +1263,23 @@ pub struct MapDoesNotContainValues<E> {
 }
 
 impl<E> MapDoesNotContainValues<E> {
+    #[deprecated = "use the function [`map_does_not_contain_values`] instead"]
     pub fn new(expected_values: impl IntoIterator<Item = E>) -> Self {
         Self {
             expected_values: Vec::from_iter(expected_values),
             extra: HashSet::new(),
         }
+    }
+}
+
+/// Creates a [`MapContainsExactlyKeys`] expectation.
+pub fn map_contains_exactly_keys<E>(
+    expected_keys: impl IntoIterator<Item = E>,
+) -> MapContainsExactlyKeys<E> {
+    MapContainsExactlyKeys {
+        expected_keys: Vec::from_iter(expected_keys),
+        missing: HashSet::new(),
+        extra: HashSet::new(),
     }
 }
 
@@ -731,6 +1291,7 @@ pub struct MapContainsExactlyKeys<E> {
 }
 
 impl<E> MapContainsExactlyKeys<E> {
+    #[deprecated = "use the function [`map_contains_exactly_keys`] instead"]
     pub fn new(expected_keys: impl IntoIterator<Item = E>) -> Self {
         Self {
             expected_keys: Vec::from_iter(expected_keys),
@@ -740,39 +1301,63 @@ impl<E> MapContainsExactlyKeys<E> {
     }
 }
 
+/// Creates a [`DoesPanic`] expectation.
+///
+/// The panic message is not being asserted. To expect to panic with a specific
+/// message, use the [`DoesPanic::with_message`] method on the newly constructed
+/// expectation.
+///
+/// # Examples
+///
+/// ```
+/// use asserting::expectations::{does_panic};
+/// use asserting::prelude::*;
+///
+/// // expect to panic with any message
+/// assert_that_code!(|| {panic!("we have a problem!");})
+///     .expecting(does_panic());
+///
+/// // expect to panic with a specific message
+/// assert_that_code!(|| {panic!("we have a problem!");})
+///     .expecting(does_panic().with_message("we have a problem!"));
+/// ```
 #[cfg(feature = "panic")]
 #[cfg_attr(docsrs, doc(cfg(feature = "panic")))]
-pub use panic::{DoesNotPanic, DoesPanic};
+pub fn does_panic() -> DoesPanic {
+    DoesPanic {
+        expected_message: None,
+        actual_message: None,
+    }
+}
 
 #[cfg(feature = "panic")]
-mod panic {
-    use std::any::Any;
+#[cfg_attr(docsrs, doc(cfg(feature = "panic")))]
+#[must_use]
+pub struct DoesPanic {
+    pub expected_message: Option<String>,
+    pub actual_message: Option<String>,
+}
 
-    #[must_use]
-    pub struct DoesPanic {
-        pub expected_message: Option<String>,
-        pub actual_message: Option<String>,
+#[cfg(feature = "panic")]
+impl DoesPanic {
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.expected_message = Some(message.into());
+        self
     }
+}
 
-    impl DoesPanic {
-        pub fn with_any_message() -> Self {
-            Self {
-                expected_message: None,
-                actual_message: None,
-            }
-        }
-
-        pub fn with_message(message: impl Into<String>) -> Self {
-            Self {
-                expected_message: Some(message.into()),
-                actual_message: None,
-            }
-        }
+/// Creates a [`DoesNotPanic`] expectation.
+#[cfg(feature = "panic")]
+#[cfg_attr(docsrs, doc(cfg(feature = "panic")))]
+pub fn does_not_panic() -> DoesNotPanic {
+    DoesNotPanic {
+        actual_message: None,
     }
+}
 
-    #[must_use]
-    #[derive(Default)]
-    pub struct DoesNotPanic {
-        pub actual_message: Option<Box<dyn Any + Send>>,
-    }
+#[cfg(feature = "panic")]
+#[cfg_attr(docsrs, doc(cfg(feature = "panic")))]
+#[must_use]
+pub struct DoesNotPanic {
+    pub actual_message: Option<Box<dyn std::any::Any + Send>>,
 }

--- a/src/float/mod.rs
+++ b/src/float/mod.rs
@@ -97,7 +97,7 @@ impl IsNanProperty for f64 {
 mod cmp {
     use crate::assertions::{AssertIsCloseToWithDefaultMargin, AssertIsCloseToWithinMargin};
     use crate::colored::mark_diff;
-    use crate::expectations::{IsCloseTo, Not};
+    use crate::expectations::{is_close_to, not, IsCloseTo};
     use crate::spec::{DiffFormat, Expectation, Expression, FailingStrategy, Invertible, Spec};
     use crate::std::{format, string::String};
     use float_cmp::{ApproxEq, F32Margin, F64Margin};
@@ -107,14 +107,12 @@ mod cmp {
         R: FailingStrategy,
     {
         fn is_close_to(self, expected: f32) -> Self {
-            self.expecting(
-                IsCloseTo::<_, F32Margin>::new(expected).within_margin((4. * f32::EPSILON, 4)),
-            )
+            self.expecting(is_close_to(expected).within_margin((4. * f32::EPSILON, 4)))
         }
 
         fn is_not_close_to(self, expected: f32) -> Self {
-            self.expecting(Not(
-                IsCloseTo::<_, F32Margin>::new(expected).within_margin((4. * f32::EPSILON, 4))
+            self.expecting(not(
+                is_close_to(expected).within_margin((4. * f32::EPSILON, 4))
             ))
         }
     }
@@ -124,11 +122,11 @@ mod cmp {
         R: FailingStrategy,
     {
         fn is_close_to_with_margin(self, expected: f32, margin: impl Into<F32Margin>) -> Self {
-            self.expecting(IsCloseTo::new(expected).within_margin(margin))
+            self.expecting(is_close_to(expected).within_margin(margin))
         }
 
         fn is_not_close_to_with_margin(self, expected: f32, margin: impl Into<F32Margin>) -> Self {
-            self.expecting(Not(IsCloseTo::new(expected).within_margin(margin)))
+            self.expecting(not(is_close_to(expected).within_margin(margin)))
         }
     }
 
@@ -137,14 +135,12 @@ mod cmp {
         R: FailingStrategy,
     {
         fn is_close_to(self, expected: f64) -> Self {
-            self.expecting(
-                IsCloseTo::<_, F64Margin>::new(expected).within_margin((4. * f64::EPSILON, 4)),
-            )
+            self.expecting(is_close_to(expected).within_margin((4. * f64::EPSILON, 4)))
         }
 
         fn is_not_close_to(self, expected: f64) -> Self {
-            self.expecting(Not(
-                IsCloseTo::<_, F64Margin>::new(expected).within_margin((4. * f64::EPSILON, 4))
+            self.expecting(not(
+                is_close_to(expected).within_margin((4. * f64::EPSILON, 4))
             ))
         }
     }
@@ -154,11 +150,11 @@ mod cmp {
         R: FailingStrategy,
     {
         fn is_close_to_with_margin(self, expected: f64, margin: impl Into<F64Margin>) -> Self {
-            self.expecting(IsCloseTo::new(expected).within_margin(margin))
+            self.expecting(is_close_to(expected).within_margin(margin))
         }
 
         fn is_not_close_to_with_margin(self, expected: f64, margin: impl Into<F64Margin>) -> Self {
-            self.expecting(Not(IsCloseTo::new(expected).within_margin(margin)))
+            self.expecting(not(is_close_to(expected).within_margin(margin)))
         }
     }
 

--- a/src/iterator/mod.rs
+++ b/src/iterator/mod.rs
@@ -7,9 +7,13 @@ use crate::colored::{
     mark_all_items_in_collection, mark_missing, mark_selected_items_in_collection, mark_unexpected,
 };
 use crate::expectations::{
-    IterContains, IterContainsAllInOrder, IterContainsAllOf, IterContainsAnyOf,
-    IterContainsExactly, IterContainsExactlyInAnyOrder, IterContainsOnly, IterContainsOnlyOnce,
-    IterContainsSequence, IterEndsWith, IterStartsWith,
+    iterator_contains, iterator_contains_all_in_order, iterator_contains_all_of,
+    iterator_contains_any_of, iterator_contains_exactly, iterator_contains_exactly_in_any_order,
+    iterator_contains_only, iterator_contains_only_once, iterator_contains_sequence,
+    iterator_ends_with, iterator_starts_with, IteratorContains, IteratorContainsAllInOrder,
+    IteratorContainsAllOf, IteratorContainsAnyOf, IteratorContainsExactly,
+    IteratorContainsExactlyInAnyOrder, IteratorContainsOnly, IteratorContainsOnlyOnce,
+    IteratorContainsSequence, IteratorEndsWith, IteratorStartsWith,
 };
 use crate::properties::DefinedOrderProperty;
 use crate::spec::{DiffFormat, Expectation, Expression, FailingStrategy, Invertible, Spec};
@@ -28,11 +32,11 @@ where
 {
     fn contains(self, expected: E) -> Spec<'a, Vec<T>, R> {
         self.mapping(Vec::from_iter)
-            .expecting(IterContains { expected })
+            .expecting(iterator_contains(expected))
     }
 }
 
-impl<T, E> Expectation<Vec<T>> for IterContains<E>
+impl<T, E> Expectation<Vec<T>> for IteratorContains<E>
 where
     T: PartialEq<E> + Debug,
     E: Debug,
@@ -58,7 +62,7 @@ where
     }
 }
 
-impl<E> Invertible for IterContains<E> {}
+impl<E> Invertible for IteratorContains<E> {}
 
 impl<'a, S, T, E, R> AssertIteratorContainsInAnyOrder<'a, Vec<T>, E, R> for Spec<'a, S, R>
 where
@@ -70,32 +74,31 @@ where
 {
     fn contains_exactly_in_any_order(self, expected: E) -> Spec<'a, Vec<T>, R> {
         self.mapping(Vec::from_iter)
-            .expecting(IterContainsExactlyInAnyOrder::new(Vec::from_iter(expected)))
+            .expecting(iterator_contains_exactly_in_any_order(expected))
     }
 
     fn contains_any_of(self, expected: E) -> Spec<'a, Vec<T>, R> {
-        self.mapping(Vec::from_iter).expecting(IterContainsAnyOf {
-            expected: Vec::from_iter(expected),
-        })
+        self.mapping(Vec::from_iter)
+            .expecting(iterator_contains_any_of(expected))
     }
 
     fn contains_all_of(self, expected: E) -> Spec<'a, Vec<T>, R> {
         self.mapping(Vec::from_iter)
-            .expecting(IterContainsAllOf::new(Vec::from_iter(expected)))
+            .expecting(iterator_contains_all_of(expected))
     }
 
     fn contains_only(self, expected: E) -> Spec<'a, Vec<T>, R> {
         self.mapping(Vec::from_iter)
-            .expecting(IterContainsOnly::new(Vec::from_iter(expected)))
+            .expecting(iterator_contains_only(expected))
     }
 
     fn contains_only_once(self, expected: E) -> Spec<'a, Vec<T>, R> {
         self.mapping(Vec::from_iter)
-            .expecting(IterContainsOnlyOnce::new(Vec::from_iter(expected)))
+            .expecting(iterator_contains_only_once(expected))
     }
 }
 
-impl<T, E> Expectation<Vec<T>> for IterContainsExactlyInAnyOrder<E>
+impl<T, E> Expectation<Vec<T>> for IteratorContainsExactlyInAnyOrder<E>
 where
     T: PartialEq<E> + Debug,
     E: Debug,
@@ -146,7 +149,7 @@ where
     }
 }
 
-impl<T, E> Expectation<Vec<T>> for IterContainsAnyOf<E>
+impl<T, E> Expectation<Vec<T>> for IteratorContainsAnyOf<E>
 where
     T: PartialEq<E> + Debug,
     E: Debug,
@@ -178,7 +181,7 @@ where
     }
 }
 
-impl<T, E> Expectation<Vec<T>> for IterContainsAllOf<E>
+impl<T, E> Expectation<Vec<T>> for IteratorContainsAllOf<E>
 where
     T: PartialEq<E> + Debug,
     E: Debug,
@@ -224,7 +227,7 @@ where
     }
 }
 
-impl<T, E> Expectation<Vec<T>> for IterContainsOnly<E>
+impl<T, E> Expectation<Vec<T>> for IteratorContainsOnly<E>
 where
     T: PartialEq<E> + Debug,
     E: Debug,
@@ -270,7 +273,7 @@ where
     }
 }
 
-impl<T, E> Expectation<Vec<T>> for IterContainsOnlyOnce<E>
+impl<T, E> Expectation<Vec<T>> for IteratorContainsOnlyOnce<E>
 where
     T: PartialEq<E> + Debug,
     E: Debug,
@@ -346,31 +349,31 @@ where
 {
     fn contains_exactly(self, expected: E) -> Spec<'a, Vec<T>, R> {
         self.mapping(Vec::from_iter)
-            .expecting(IterContainsExactly::new(Vec::from_iter(expected)))
+            .expecting(iterator_contains_exactly(expected))
     }
 
     fn contains_sequence(self, expected: E) -> Spec<'a, Vec<T>, R> {
         self.mapping(Vec::from_iter)
-            .expecting(IterContainsSequence::new(Vec::from_iter(expected)))
+            .expecting(iterator_contains_sequence(expected))
     }
 
     fn contains_all_in_order(self, expected: E) -> Spec<'a, Vec<T>, R> {
         self.mapping(Vec::from_iter)
-            .expecting(IterContainsAllInOrder::new(Vec::from_iter(expected)))
+            .expecting(iterator_contains_all_in_order(expected))
     }
 
     fn starts_with(self, expected: E) -> Spec<'a, Vec<T>, R> {
         self.mapping(Vec::from_iter)
-            .expecting(IterStartsWith::new(Vec::from_iter(expected)))
+            .expecting(iterator_starts_with(expected))
     }
 
     fn ends_with(self, expected: E) -> Spec<'a, Vec<T>, R> {
         self.mapping(Vec::from_iter)
-            .expecting(IterEndsWith::new(Vec::from_iter(expected)))
+            .expecting(iterator_ends_with(expected))
     }
 }
 
-impl<T, E> Expectation<Vec<T>> for IterContainsExactly<E>
+impl<T, E> Expectation<Vec<T>> for IteratorContainsExactly<E>
 where
     T: PartialEq<E> + Debug,
     E: Debug,
@@ -456,7 +459,7 @@ where
     }
 }
 
-impl<T, E> Expectation<Vec<T>> for IterContainsSequence<E>
+impl<T, E> Expectation<Vec<T>> for IteratorContainsSequence<E>
 where
     T: PartialEq<E> + Debug,
     E: Debug,
@@ -547,7 +550,7 @@ where
     }
 }
 
-impl<T, E> Expectation<Vec<T>> for IterContainsAllInOrder<E>
+impl<T, E> Expectation<Vec<T>> for IteratorContainsAllInOrder<E>
 where
     T: PartialEq<E> + Debug,
     E: Debug,
@@ -591,7 +594,7 @@ where
     }
 }
 
-impl<T, E> Expectation<Vec<T>> for IterStartsWith<E>
+impl<T, E> Expectation<Vec<T>> for IteratorStartsWith<E>
 where
     T: PartialEq<E> + Debug,
     E: Debug,
@@ -644,7 +647,7 @@ where
     }
 }
 
-impl<T, E> Expectation<Vec<T>> for IterEndsWith<E>
+impl<T, E> Expectation<Vec<T>> for IteratorEndsWith<E>
 where
     T: PartialEq<E> + Debug,
     E: Debug,

--- a/src/length.rs
+++ b/src/length.rs
@@ -3,8 +3,9 @@
 use crate::assertions::{AssertEmptiness, AssertHasLength};
 use crate::colored::{mark_missing, mark_unexpected};
 use crate::expectations::{
-    HasAtLeastLength, HasAtMostLength, HasLength, HasLengthGreaterThan, HasLengthInRange,
-    HasLengthLessThan, IsEmpty, Not,
+    has_at_least_length, has_at_most_length, has_length, has_length_greater_than,
+    has_length_in_range, has_length_less_than, is_empty, not, HasAtLeastLength, HasAtMostLength,
+    HasLength, HasLengthGreaterThan, HasLengthInRange, HasLengthLessThan, IsEmpty,
 };
 use crate::properties::{IsEmptyProperty, LengthProperty};
 use crate::spec::{DiffFormat, Expectation, Expression, FailingStrategy, Invertible, Spec};
@@ -18,11 +19,11 @@ where
     R: FailingStrategy,
 {
     fn is_empty(self) -> Self {
-        self.expecting(IsEmpty)
+        self.expecting(is_empty())
     }
 
     fn is_not_empty(self) -> Self {
-        self.expecting(Not(IsEmpty))
+        self.expecting(not(is_empty()))
     }
 }
 
@@ -59,30 +60,30 @@ where
     R: FailingStrategy,
 {
     fn has_length(self, expected_length: usize) -> Self {
-        self.expecting(HasLength { expected_length })
+        self.expecting(has_length(expected_length))
     }
 
     fn has_length_in_range<U>(self, expected_range: U) -> Self
     where
         U: RangeBounds<usize> + Debug,
     {
-        self.expecting(HasLengthInRange::new(expected_range))
+        self.expecting(has_length_in_range(expected_range))
     }
 
     fn has_length_less_than(self, expected_length: usize) -> Self {
-        self.expecting(HasLengthLessThan { expected_length })
+        self.expecting(has_length_less_than(expected_length))
     }
 
     fn has_length_greater_than(self, expected_length: usize) -> Self {
-        self.expecting(HasLengthGreaterThan { expected_length })
+        self.expecting(has_length_greater_than(expected_length))
     }
 
     fn has_at_most_length(self, expected_length: usize) -> Self {
-        self.expecting(HasAtMostLength { expected_length })
+        self.expecting(has_at_most_length(expected_length))
     }
 
     fn has_at_least_length(self, expected_length: usize) -> Self {
-        self.expecting(HasAtLeastLength { expected_length })
+        self.expecting(has_at_least_length(expected_length))
     }
 }
 

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -4,8 +4,10 @@ use crate::colored::{
     mark_selected_items_in_collection, mark_unexpected_string,
 };
 use crate::expectations::{
+    map_contains_exactly_keys, map_contains_key, map_contains_keys, map_contains_value,
+    map_contains_values, map_does_not_contain_keys, map_does_not_contain_values, not,
     MapContainsExactlyKeys, MapContainsKey, MapContainsKeys, MapContainsValue, MapContainsValues,
-    MapDoesNotContainKeys, MapDoesNotContainValues, Not,
+    MapDoesNotContainKeys, MapDoesNotContainValues,
 };
 use crate::iterator::collect_selected_values;
 use crate::properties::MapProperties;
@@ -25,23 +27,23 @@ where
     R: FailingStrategy,
 {
     fn contains_key(self, expected_key: E) -> Self {
-        self.expecting(MapContainsKey { expected_key })
+        self.expecting(map_contains_key(expected_key))
     }
 
     fn does_not_contain_key(self, expected_key: E) -> Self {
-        self.expecting(Not(MapContainsKey { expected_key }))
+        self.expecting(not(map_contains_key(expected_key)))
     }
 
     fn contains_keys(self, expected_keys: impl IntoIterator<Item = E>) -> Self {
-        self.expecting(MapContainsKeys::new(expected_keys))
+        self.expecting(map_contains_keys(expected_keys))
     }
 
     fn does_not_contain_keys(self, expected_keys: impl IntoIterator<Item = E>) -> Self {
-        self.expecting(MapDoesNotContainKeys::new(expected_keys))
+        self.expecting(map_does_not_contain_keys(expected_keys))
     }
 
     fn contains_exactly_keys(self, expected_keys: impl IntoIterator<Item = E>) -> Self {
-        self.expecting(MapContainsExactlyKeys::new(expected_keys))
+        self.expecting(map_contains_exactly_keys(expected_keys))
     }
 }
 
@@ -264,19 +266,19 @@ where
     R: FailingStrategy,
 {
     fn contains_value(self, expected_value: E) -> Self {
-        self.expecting(MapContainsValue { expected_value })
+        self.expecting(map_contains_value(expected_value))
     }
 
     fn does_not_contain_value(self, expected_value: E) -> Self {
-        self.expecting(Not(MapContainsValue { expected_value }))
+        self.expecting(not(map_contains_value(expected_value)))
     }
 
     fn contains_values(self, expected_values: impl IntoIterator<Item = E>) -> Self {
-        self.expecting(MapContainsValues::new(expected_values))
+        self.expecting(map_contains_values(expected_values))
     }
 
     fn does_not_contain_values(self, expected_values: impl IntoIterator<Item = E>) -> Self {
-        self.expecting(MapDoesNotContainValues::new(expected_values))
+        self.expecting(map_does_not_contain_values(expected_values))
     }
 }
 

--- a/src/number.rs
+++ b/src/number.rs
@@ -5,8 +5,9 @@ use crate::assertions::{
 };
 use crate::colored::{mark_missing, mark_missing_string, mark_unexpected};
 use crate::expectations::{
-    HasPrecisionOf, HasScaleOf, IsANumber, IsFinite, IsInfinite, IsInteger, IsNegative, IsOne,
-    IsPositive, IsZero, Not,
+    has_precision_of, has_scale_of, is_a_number, is_finite, is_infinite, is_integer, is_negative,
+    is_one, is_positive, is_zero, not, HasPrecisionOf, HasScaleOf, IsANumber, IsFinite, IsInfinite,
+    IsInteger, IsNegative, IsOne, IsPositive, IsZero,
 };
 use crate::properties::{
     AdditiveIdentityProperty, DecimalProperties, InfinityProperty, IsNanProperty,
@@ -23,19 +24,19 @@ where
     R: FailingStrategy,
 {
     fn is_negative(self) -> Self {
-        self.expecting(IsNegative)
+        self.expecting(is_negative())
     }
 
     fn is_not_negative(self) -> Self {
-        self.expecting(Not(IsNegative))
+        self.expecting(not(is_negative()))
     }
 
     fn is_positive(self) -> Self {
-        self.expecting(IsPositive)
+        self.expecting(is_positive())
     }
 
     fn is_not_positive(self) -> Self {
-        self.expecting(Not(IsPositive))
+        self.expecting(not(is_positive()))
     }
 }
 
@@ -101,11 +102,11 @@ where
     R: FailingStrategy,
 {
     fn is_zero(self) -> Self {
-        self.expecting(IsZero)
+        self.expecting(is_zero())
     }
 
     fn is_one(self) -> Self {
-        self.expecting(IsOne)
+        self.expecting(is_one())
     }
 }
 
@@ -163,11 +164,11 @@ where
     R: FailingStrategy,
 {
     fn is_infinite(self) -> Self {
-        self.expecting(IsInfinite)
+        self.expecting(is_infinite())
     }
 
     fn is_finite(self) -> Self {
-        self.expecting(IsFinite)
+        self.expecting(is_finite())
     }
 }
 
@@ -233,11 +234,11 @@ where
     R: FailingStrategy,
 {
     fn is_not_a_number(self) -> Self {
-        self.expecting(Not(IsANumber))
+        self.expecting(not(is_a_number()))
     }
 
     fn is_a_number(self) -> Self {
-        self.expecting(IsANumber)
+        self.expecting(is_a_number())
     }
 }
 
@@ -275,15 +276,15 @@ where
     R: FailingStrategy,
 {
     fn has_scale_of(self, expected_scale: i64) -> Self {
-        self.expecting(HasScaleOf { expected_scale })
+        self.expecting(has_scale_of(expected_scale))
     }
 
     fn has_precision_of(self, expected_precision: u64) -> Self {
-        self.expecting(HasPrecisionOf { expected_precision })
+        self.expecting(has_precision_of(expected_precision))
     }
 
     fn is_integer(self) -> Self {
-        self.expecting(IsInteger)
+        self.expecting(is_integer())
     }
 }
 

--- a/src/option/mod.rs
+++ b/src/option/mod.rs
@@ -4,7 +4,7 @@ use crate::assertions::{
     AssertBorrowedOptionValue, AssertHasValue, AssertOption, AssertOptionValue,
 };
 use crate::colored::{mark_missing, mark_unexpected};
-use crate::expectations::{HasValue, IsNone, IsSome};
+use crate::expectations::{has_value, is_none, is_some, HasValue, IsNone, IsSome};
 use crate::spec::{
     DiffFormat, Expectation, Expression, FailingStrategy, Invertible, Spec, Unknown,
 };
@@ -17,11 +17,11 @@ where
     R: FailingStrategy,
 {
     fn is_some(self) -> Self {
-        self.expecting(IsSome)
+        self.expecting(is_some())
     }
 
     fn is_none(self) -> Self {
-        self.expecting(IsNone)
+        self.expecting(is_none())
     }
 }
 
@@ -31,11 +31,11 @@ where
     R: FailingStrategy,
 {
     fn is_some(self) -> Self {
-        self.expecting(IsSome)
+        self.expecting(is_some())
     }
 
     fn is_none(self) -> Self {
-        self.expecting(IsNone)
+        self.expecting(is_none())
     }
 }
 
@@ -74,7 +74,7 @@ where
     R: FailingStrategy,
 {
     fn has_value(self, expected: E) -> Self {
-        self.expecting(HasValue { expected })
+        self.expecting(has_value(expected))
     }
 }
 
@@ -85,7 +85,7 @@ where
     R: FailingStrategy,
 {
     fn has_value(self, expected: E) -> Self {
-        self.expecting(HasValue { expected })
+        self.expecting(has_value(expected))
     }
 }
 

--- a/src/order/mod.rs
+++ b/src/order/mod.rs
@@ -3,6 +3,7 @@
 use crate::assertions::AssertOrder;
 use crate::colored::{mark_missing, mark_unexpected};
 use crate::expectations::{
+    is_after, is_at_least, is_at_most, is_before, is_between, is_greater_than, is_less_than,
     IsAfter, IsAtLeast, IsAtMost, IsBefore, IsBetween, IsGreaterThan, IsLessThan,
 };
 use crate::spec::{DiffFormat, Expectation, Expression, FailingStrategy, Invertible, Spec};
@@ -16,31 +17,31 @@ where
     R: FailingStrategy,
 {
     fn is_less_than(self, expected: E) -> Self {
-        self.expecting(IsLessThan { expected })
+        self.expecting(is_less_than(expected))
     }
 
     fn is_greater_than(self, expected: E) -> Self {
-        self.expecting(IsGreaterThan { expected })
+        self.expecting(is_greater_than(expected))
     }
 
     fn is_at_most(self, expected: E) -> Self {
-        self.expecting(IsAtMost { expected })
+        self.expecting(is_at_most(expected))
     }
 
     fn is_at_least(self, expected: E) -> Self {
-        self.expecting(IsAtLeast { expected })
+        self.expecting(is_at_least(expected))
     }
 
     fn is_before(self, expected: E) -> Self {
-        self.expecting(IsBefore { expected })
+        self.expecting(is_before(expected))
     }
 
     fn is_after(self, expected: E) -> Self {
-        self.expecting(IsAfter { expected })
+        self.expecting(is_after(expected))
     }
 
     fn is_between(self, min: E, max: E) -> Self {
-        self.expecting(IsBetween { min, max })
+        self.expecting(is_between(min, max))
     }
 }
 

--- a/src/panic/mod.rs
+++ b/src/panic/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::assertions::AssertCodePanics;
 use crate::colored::{mark_missing_string, mark_unexpected_string};
-use crate::expectations::{DoesNotPanic, DoesPanic};
+use crate::expectations::{does_not_panic, does_panic, DoesNotPanic, DoesPanic};
 use crate::spec::{Code, DiffFormat, Expectation, Expression, FailingStrategy, Spec};
 use crate::std::any::Any;
 use crate::std::panic;
@@ -16,16 +16,15 @@ where
     R: FailingStrategy,
 {
     fn does_not_panic(self) -> Spec<'a, (), R> {
-        self.expecting(DoesNotPanic::default()).mapping(|_| ())
+        self.expecting(does_not_panic()).mapping(|_| ())
     }
 
     fn panics(self) -> Spec<'a, (), R> {
-        self.expecting(DoesPanic::with_any_message())
-            .mapping(|_| ())
+        self.expecting(does_panic()).mapping(|_| ())
     }
 
     fn panics_with_message(self, message: impl Into<String>) -> Spec<'a, (), R> {
-        self.expecting(DoesPanic::with_message(message))
+        self.expecting(does_panic().with_message(message))
             .mapping(|_| ())
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -18,7 +18,6 @@ pub use super::{
     assert_that,
     assertions::*,
     colored::{DEFAULT_DIFF_FORMAT, DIFF_FORMAT_NO_HIGHLIGHT},
-    expectations::{all, any, not, rec},
     properties::*,
     spec::{assert_that, verify_that, CollectFailures, Location, PanicOnFail},
     verify_that,

--- a/src/range/mod.rs
+++ b/src/range/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::assertions::AssertInRange;
 use crate::colored::{mark_missing, mark_missing_string, mark_unexpected};
-use crate::expectations::{IsInRange, Not};
+use crate::expectations::{is_in_range, not, IsInRange};
 use crate::properties::IsEmptyProperty;
 use crate::spec::{DiffFormat, Expectation, Expression, FailingStrategy, Invertible, Spec};
 use crate::std::fmt::Debug;
@@ -38,14 +38,14 @@ where
     where
         U: RangeBounds<E> + Debug,
     {
-        self.expecting(IsInRange::new(range))
+        self.expecting(is_in_range(range))
     }
 
     fn is_not_in_range<U>(self, range: U) -> Self
     where
         U: RangeBounds<E> + Debug,
     {
-        self.expecting(Not(IsInRange::new(range)))
+        self.expecting(not(is_in_range(range)))
     }
 }
 

--- a/src/result/mod.rs
+++ b/src/result/mod.rs
@@ -5,7 +5,9 @@ use crate::assertions::{
     AssertResultValue,
 };
 use crate::colored::{mark_missing, mark_unexpected};
-use crate::expectations::{HasError, HasValue, IsEqualTo, IsErr, IsOk};
+use crate::expectations::{
+    has_error, has_value, is_equal_to, is_err, is_ok, HasError, HasValue, IsErr, IsOk,
+};
 use crate::spec::{
     DiffFormat, Expectation, Expression, FailingStrategy, Invertible, Spec, Unknown,
 };
@@ -22,11 +24,11 @@ where
     R: FailingStrategy,
 {
     fn is_ok(self) -> Self {
-        self.expecting(IsOk)
+        self.expecting(is_ok())
     }
 
     fn is_err(self) -> Self {
-        self.expecting(IsErr)
+        self.expecting(is_err())
     }
 }
 
@@ -37,11 +39,11 @@ where
     R: FailingStrategy,
 {
     fn is_ok(self) -> Self {
-        self.expecting(IsOk)
+        self.expecting(is_ok())
     }
 
     fn is_err(self) -> Self {
-        self.expecting(IsErr)
+        self.expecting(is_err())
     }
 }
 
@@ -101,7 +103,7 @@ where
     R: FailingStrategy,
 {
     fn has_value(self, expected: X) -> Self {
-        self.expecting(HasValue { expected })
+        self.expecting(has_value(expected))
     }
 }
 
@@ -113,7 +115,7 @@ where
     R: FailingStrategy,
 {
     fn has_value(self, expected: X) -> Self {
-        self.expecting(HasValue { expected })
+        self.expecting(has_value(expected))
     }
 }
 
@@ -125,7 +127,7 @@ where
     R: FailingStrategy,
 {
     fn has_error(self, expected: X) -> Self {
-        self.expecting(HasError { expected })
+        self.expecting(has_error(expected))
     }
 }
 
@@ -137,7 +139,7 @@ where
     R: FailingStrategy,
 {
     fn has_error(self, expected: X) -> Self {
-        self.expecting(HasError { expected })
+        self.expecting(has_error(expected))
     }
 }
 
@@ -157,7 +159,7 @@ where
             Err(error) => {
                 error.to_string()
             },
-        }).expecting(IsEqualTo {expected})
+        }).expecting(is_equal_to(expected))
     }
 }
 
@@ -177,7 +179,7 @@ where
             Err(error) => {
                 error.to_string()
             },
-        }).expecting(IsEqualTo {expected})
+        }).expecting(is_equal_to(expected))
     }
 }
 

--- a/src/spec/mod.rs
+++ b/src/spec/mod.rs
@@ -1,7 +1,7 @@
 //! This is the core of the `asserting` crate.
 
 use crate::colored;
-use crate::expectations::{satisfies, Predicate};
+use crate::expectations::satisfies;
 use crate::std::any;
 use crate::std::borrow::Cow;
 use crate::std::error::Error as StdError;
@@ -965,10 +965,7 @@ where
     where
         P: Fn(&S) -> bool,
     {
-        self.expecting(Predicate {
-            predicate,
-            message: Some(message.into()),
-        })
+        self.expecting(satisfies(predicate).with_message(message))
     }
 
     /// Fails the assertion according the current failing strategy of this

--- a/src/spec/mod.rs
+++ b/src/spec/mod.rs
@@ -1,7 +1,7 @@
 //! This is the core of the `asserting` crate.
 
 use crate::colored;
-use crate::expectations::Predicate;
+use crate::expectations::{satisfies, Predicate};
 use crate::std::any;
 use crate::std::borrow::Cow;
 use crate::std::error::Error as StdError;
@@ -923,10 +923,7 @@ where
     where
         P: Fn(&S) -> bool,
     {
-        self.expecting(Predicate {
-            predicate,
-            message: None,
-        })
+        self.expecting(satisfies(predicate))
     }
 
     /// Asserts whether the given predicate is meet.

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -7,7 +7,8 @@ use crate::colored::{
     mark_unexpected_char_in_string, mark_unexpected_string, mark_unexpected_substring_in_string,
 };
 use crate::expectations::{
-    Not, StringContains, StringContainsAnyOf, StringEndsWith, StringStartWith,
+    not, string_contains, string_contains_any_of, string_ends_with, string_starts_with,
+    StringContains, StringContainsAnyOf, StringEndsWith, StringStartWith,
 };
 use crate::properties::{CharCountProperty, DefinedOrderProperty, IsEmptyProperty, LengthProperty};
 use crate::spec::{DiffFormat, Expectation, Expression, FailingStrategy, Invertible, Spec};
@@ -69,27 +70,27 @@ where
     R: FailingStrategy,
 {
     fn contains(self, pattern: &'a str) -> Self {
-        self.expecting(StringContains { expected: pattern })
+        self.expecting(string_contains(pattern))
     }
 
     fn does_not_contain(self, pattern: &'a str) -> Self {
-        self.expecting(Not(StringContains { expected: pattern }))
+        self.expecting(not(string_contains(pattern)))
     }
 
     fn starts_with(self, pattern: &str) -> Self {
-        self.expecting(StringStartWith { expected: pattern })
+        self.expecting(string_starts_with(pattern))
     }
 
     fn does_not_start_with(self, pattern: &'a str) -> Self {
-        self.expecting(Not(StringStartWith { expected: pattern }))
+        self.expecting(not(string_starts_with(pattern)))
     }
 
     fn ends_with(self, pattern: &str) -> Self {
-        self.expecting(StringEndsWith { expected: pattern })
+        self.expecting(string_ends_with(pattern))
     }
 
     fn does_not_end_with(self, pattern: &'a str) -> Self {
-        self.expecting(Not(StringEndsWith { expected: pattern }))
+        self.expecting(not(string_ends_with(pattern)))
     }
 }
 
@@ -99,27 +100,27 @@ where
     R: FailingStrategy,
 {
     fn contains(self, pattern: String) -> Self {
-        self.expecting(StringContains { expected: pattern })
+        self.expecting(string_contains(pattern))
     }
 
     fn does_not_contain(self, pattern: String) -> Self {
-        self.expecting(Not(StringContains { expected: pattern }))
+        self.expecting(not(string_contains(pattern)))
     }
 
     fn starts_with(self, pattern: String) -> Self {
-        self.expecting(StringStartWith { expected: pattern })
+        self.expecting(string_starts_with(pattern))
     }
 
     fn does_not_start_with(self, pattern: String) -> Self {
-        self.expecting(Not(StringStartWith { expected: pattern }))
+        self.expecting(not(string_starts_with(pattern)))
     }
 
     fn ends_with(self, pattern: String) -> Self {
-        self.expecting(StringEndsWith { expected: pattern })
+        self.expecting(string_ends_with(pattern))
     }
 
     fn does_not_end_with(self, pattern: String) -> Self {
-        self.expecting(Not(StringEndsWith { expected: pattern }))
+        self.expecting(not(string_ends_with(pattern)))
     }
 }
 
@@ -129,27 +130,27 @@ where
     R: FailingStrategy,
 {
     fn contains(self, expected: char) -> Self {
-        self.expecting(StringContains { expected })
+        self.expecting(string_contains(expected))
     }
 
     fn does_not_contain(self, pattern: char) -> Self {
-        self.expecting(Not(StringContains { expected: pattern }))
+        self.expecting(not(string_contains(pattern)))
     }
 
     fn starts_with(self, expected: char) -> Self {
-        self.expecting(StringStartWith { expected })
+        self.expecting(string_starts_with(expected))
     }
 
     fn does_not_start_with(self, pattern: char) -> Self {
-        self.expecting(Not(StringStartWith { expected: pattern }))
+        self.expecting(not(string_starts_with(pattern)))
     }
 
     fn ends_with(self, pattern: char) -> Self {
-        self.expecting(StringEndsWith { expected: pattern })
+        self.expecting(string_ends_with(pattern))
     }
 
     fn does_not_end_with(self, pattern: char) -> Self {
-        self.expecting(Not(StringEndsWith { expected: pattern }))
+        self.expecting(not(string_ends_with(pattern)))
     }
 }
 
@@ -484,11 +485,11 @@ where
     R: FailingStrategy,
 {
     fn contains_any_of(self, expected: &'a [char]) -> Self {
-        self.expecting(StringContainsAnyOf { expected })
+        self.expecting(string_contains_any_of(expected))
     }
 
     fn does_not_contain_any_of(self, expected: &'a [char]) -> Self {
-        self.expecting(Not(StringContainsAnyOf { expected }))
+        self.expecting(not(string_contains_any_of(expected)))
     }
 }
 
@@ -498,11 +499,11 @@ where
     R: FailingStrategy,
 {
     fn contains_any_of(self, expected: [char; N]) -> Self {
-        self.expecting(StringContainsAnyOf { expected })
+        self.expecting(string_contains_any_of(expected))
     }
 
     fn does_not_contain_any_of(self, expected: [char; N]) -> Self {
-        self.expecting(Not(StringContainsAnyOf { expected }))
+        self.expecting(not(string_contains_any_of(expected)))
     }
 }
 
@@ -512,11 +513,11 @@ where
     R: FailingStrategy,
 {
     fn contains_any_of(self, expected: &'a [char; N]) -> Self {
-        self.expecting(StringContainsAnyOf { expected })
+        self.expecting(string_contains_any_of(expected))
     }
 
     fn does_not_contain_any_of(self, expected: &'a [char; N]) -> Self {
-        self.expecting(Not(StringContainsAnyOf { expected }))
+        self.expecting(not(string_contains_any_of(expected)))
     }
 }
 
@@ -701,7 +702,7 @@ impl<const N: usize> Invertible for StringContainsAnyOf<&[char; N]> {}
 mod regex {
     use crate::assertions::AssertStringMatches;
     use crate::colored::{mark_missing_string, mark_unexpected_string};
-    use crate::expectations::{Not, StringMatches};
+    use crate::expectations::{not, string_matches, StringMatches};
     use crate::spec::{DiffFormat, Expectation, Expression, FailingStrategy, Invertible, Spec};
     use crate::std::fmt::Debug;
 
@@ -711,11 +712,11 @@ mod regex {
         R: FailingStrategy,
     {
         fn matches(self, regex_pattern: &str) -> Self {
-            self.expecting(StringMatches::new(regex_pattern))
+            self.expecting(string_matches(regex_pattern))
         }
 
         fn does_not_match(self, regex_pattern: &str) -> Self {
-            self.expecting(Not(StringMatches::new(regex_pattern)))
+            self.expecting(not(string_matches(regex_pattern)))
         }
     }
 


### PR DESCRIPTION
When composing custom expectations using the expectations combinators (`not`, `all`, `any`) it should be possible to construct the expectations in a convenient and readable form. Therefore we should provide constructor functions for expectations, e.g.

instead of :

```Rust
let custom_expectation = all((not(IsZero), IsAtLeast { expected: -40 }, IsAtMost { expected: 100 }));
```

we can write:

```Rust
let custom_expectation = all((not(is_zero()), is_at_least(-40), is_at_most(100)));
```

Implemented a constructor function for each of the provided expectations.