### PR TITLE
feat: assert types formatted for debug and display

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,22 @@ for types that implement `std::error::Error`.
 | has_source         | verify that an error has some source                                                               |
 | has_source_message | verify that an error has a source which converts to a string that is equal to the expected message |
 
+### Debug and Display string
+
+for types that implement `core::fmt::Debug`:
+
+| assertion                   | description                                                                |
+|-----------------------------|----------------------------------------------------------------------------|
+| has_debug_message           | verify that a type formatted for debug is equal to the expected string     |                                                 
+| does_not_have_debug_message | verify that a type formatted for debug is not equal to the expected string |
+
+for types that implement `core::fmt::Display`:
+
+| assertion                     | description                                                                  |
+|-------------------------------|------------------------------------------------------------------------------|
+| has_display_message           | verify that a type formatted for display is equal to the expected string     |                                                 
+| does_not_have_display_message | verify that a type formatted for display is not equal to the expected string |
+
 ### Emptiness
 
 for collections and strings.

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -2219,6 +2219,145 @@ pub trait AssertErrorHasSource<'a, R> {
     ) -> Spec<'a, Option<String>, R>;
 }
 
+/// Assert a type formatted into a debug string.
+///
+/// The subject's type must implement `Debug` and the expected type must
+/// implement `AsRef<str>`.
+///
+/// # Examples
+///
+/// ```
+/// use asserting::prelude::*;
+///
+/// #[derive(Debug)]
+/// struct Foo {
+///     hello: String,
+/// }
+///
+/// let subject = Foo { hello: "World".into() };
+///
+/// assert_that!(&subject).has_debug_message("Foo { hello: \"World\" }");
+/// assert_that!(&subject).does_not_have_debug_message("Bar { hello: \"World\" }");
+/// ```
+pub trait AssertHasDebugMessage<E> {
+    /// Verifies that a subject formatted for debugging results in the expected
+    /// string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use asserting::prelude::*;
+    ///
+    /// #[derive(Debug)]
+    /// struct Foo {
+    ///     hello: String,
+    /// }
+    ///
+    /// let subject = Foo { hello: "World".into() };
+    ///
+    /// assert_that!(subject).has_debug_message("Foo { hello: \"World\" }");
+    /// ```
+    #[track_caller]
+    fn has_debug_message(self, expected: E) -> Self;
+
+    /// Verifies that a subject formatted for debugging does not result in the
+    /// expected string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use asserting::prelude::*;
+    ///
+    /// #[derive(Debug)]
+    /// struct Foo {
+    ///     hello: String,
+    /// }
+    ///
+    /// let subject = Foo { hello: "World".into() };
+    ///
+    /// assert_that!(subject).does_not_have_debug_message("Hello World");
+    /// ```
+    #[track_caller]
+    fn does_not_have_debug_message(self, expected: E) -> Self;
+}
+
+/// Assert a type formatted into a display string.
+///
+/// The subject's type must implement `Display` and the expected type must
+/// implement `AsRef<str>`.
+///
+/// # Examples
+///
+/// ```
+/// use core::fmt::{self, Display};
+/// use asserting::prelude::*;
+///
+/// struct Foo {
+///     hello: String,
+/// }
+///
+/// impl Display for Foo {fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+///         write!(f, "Hello {}", self.hello)
+///     }
+/// }
+///
+/// let subject = Foo { hello: "World".into() };
+///
+/// assert_that!(&subject).has_display_message("Hello World");
+/// assert_that!(&subject).does_not_have_display_message("Foo { hello: \"World\" }");
+/// ```
+pub trait AssertHasDisplayMessage<E> {
+    /// Verifies that a subject formatted for display results in the expected
+    /// string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use core::fmt::{self, Display};
+    /// use asserting::prelude::*;
+    ///
+    /// struct Foo {
+    ///     hello: String,
+    /// }
+    ///
+    /// impl Display for Foo {fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    ///         write!(f, "Hello {}", self.hello)
+    ///     }
+    /// }
+    ///
+    /// let subject = Foo { hello: "World".into() };
+    ///
+    /// assert_that!(&subject).has_display_message("Hello World");
+    /// ```
+    #[track_caller]
+    fn has_display_message(self, expected: E) -> Self;
+
+    /// Verifies that a subject formatted for display does not result in the
+    /// expected string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use core::fmt::{self, Display};
+    /// use asserting::prelude::*;
+    ///
+    /// struct Foo {
+    ///     hello: String,
+    /// }
+    ///
+    /// impl Display for Foo {fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    ///         write!(f, "Hello {}", self.hello)
+    ///     }
+    /// }
+    ///
+    /// let subject = Foo { hello: "World".into() };
+    ///
+    /// assert_that!(&subject).does_not_have_display_message("Foo { hello: \"World\" }");
+    /// ```
+    #[track_caller]
+    fn does_not_have_display_message(self, expected: E) -> Self;
+}
+
 /// Assert that a string contains a substring or character.
 ///
 /// # Examples

--- a/src/colored/mod.rs
+++ b/src/colored/mod.rs
@@ -193,6 +193,26 @@ where
     S: Debug + ?Sized,
     E: Debug + ?Sized,
 {
+    let actual = format!("{actual:?}");
+    let expected = format!("{expected:?}");
+    mark_diff_impl(&actual, &expected, format)
+}
+
+/// Highlights differences between the expected and the actual string and
+/// returns new strings with marked differences.
+///
+/// The style for marking differences is determined by the provided
+/// [`DiffFormat`].
+///
+/// A diff algorithm is applied to determine the differences between the
+/// expected and the actual string. The differences are marked according to the
+/// provided [`DiffFormat`].
+///
+/// It returns a tuple of two `String`s. The first string contains the actual
+/// value, and the second one contains the expected value. Both strings
+/// are a copy of the actual respectively expected string but with differences
+/// highlighted.
+pub fn mark_diff_str(actual: &str, expected: &str, format: &DiffFormat) -> (String, String) {
     mark_diff_impl(actual, expected, format)
 }
 
@@ -792,12 +812,8 @@ mod without_colored_feature {
     }
 
     #[inline]
-    pub fn mark_diff_impl<S, E>(actual: &S, expected: &E, _format: &DiffFormat) -> (String, String)
-    where
-        S: Debug + ?Sized,
-        E: Debug + ?Sized,
-    {
-        (format!("{actual:?}"), format!("{expected:?}"))
+    pub fn mark_diff_impl(actual: &str, expected: &str, _format: &DiffFormat) -> (String, String) {
+        (actual.to_string(), expected.to_string())
     }
 
     #[inline]
@@ -1025,16 +1041,12 @@ mod with_colored_feature {
     }
 
     #[inline]
-    pub fn mark_diff_impl<S, E>(actual: &S, expected: &E, format: &DiffFormat) -> (String, String)
-    where
-        S: Debug + ?Sized,
-        E: Debug + ?Sized,
-    {
+    pub fn mark_diff_impl(actual: &str, expected: &str, format: &DiffFormat) -> (String, String) {
         use crate::std::vec::Vec;
         use sdiff::Diff;
 
-        let actual = format!("{actual:?}").chars().collect::<Vec<_>>();
-        let expected = format!("{expected:?}").chars().collect::<Vec<_>>();
+        let actual = actual.chars().collect::<Vec<_>>();
+        let expected = expected.chars().collect::<Vec<_>>();
         let mut marked_actual = Vec::with_capacity(actual.len());
         let mut marked_expected = Vec::with_capacity(expected.len());
         let diffs = sdiff::diff(&actual, &expected);

--- a/src/error/tests.rs
+++ b/src/error/tests.rs
@@ -38,6 +38,126 @@ impl Display for SourceError {
 impl Error for SourceError {}
 
 #[test]
+fn error_has_debug_message() {
+    let error = SuperError {
+        source: SourceError::Bar,
+    };
+
+    assert_that(error).has_debug_message("SuperError { source: Bar }");
+}
+
+#[test]
+fn verify_error_has_debug_message_fails() {
+    let error = SuperError {
+        source: SourceError::Foo,
+    };
+
+    let failures = verify_that(error)
+        .has_debug_message("SuperError { source: Bar }")
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r#"assertion failed: expected subject to have debug message "SuperError { source: Bar }"
+   but was: SuperError { source: Foo }
+  expected: SuperError { source: Bar }
+"#
+        ]
+    );
+}
+
+#[test]
+fn error_does_not_have_debug_message() {
+    let error = SuperError {
+        source: SourceError::Bar,
+    };
+
+    assert_that(error).does_not_have_debug_message("SuperError { source: Foo }");
+}
+
+#[test]
+fn verify_error_does_not_have_debug_message_fails() {
+    let error = SuperError {
+        source: SourceError::Bar,
+    };
+
+    let failures = verify_that(error)
+        .does_not_have_debug_message("SuperError { source: Bar }")
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r#"assertion failed: expected subject to not have debug message "SuperError { source: Bar }"
+   but was: SuperError { source: Bar }
+  expected: not SuperError { source: Bar }
+"#
+        ]
+    );
+}
+
+#[test]
+fn error_has_display_message() {
+    let error = SuperError {
+        source: SourceError::Bar,
+    };
+
+    assert_that(error).has_display_message("super-error caused by bar error");
+}
+
+#[test]
+fn verify_error_has_display_message_fails() {
+    let error = SuperError {
+        source: SourceError::Foo,
+    };
+
+    let failures = verify_that(error)
+        .has_display_message("super-error caused by bar error")
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r#"assertion failed: expected subject to have display message "super-error caused by bar error"
+   but was: "super-error caused by foo error"
+  expected: "super-error caused by bar error"
+"#
+        ]
+    );
+}
+
+#[test]
+fn error_does_not_have_display_message() {
+    let error = SuperError {
+        source: SourceError::Bar,
+    };
+
+    assert_that(error).does_not_have_display_message("super-error caused by foo error");
+}
+
+#[test]
+fn verify_error_does_not_have_display_message_fails() {
+    let error = SuperError {
+        source: SourceError::Foo,
+    };
+
+    let failures = verify_that(error)
+        .does_not_have_display_message("super-error caused by foo error")
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r#"assertion failed: expected subject to not have display message "super-error caused by foo error"
+   but was: "super-error caused by foo error"
+  expected: not "super-error caused by foo error"
+"#
+        ]
+    );
+}
+
+#[test]
 fn source_error_has_no_source() {
     let error = SourceError::Foo;
 

--- a/src/expectations.rs
+++ b/src/expectations.rs
@@ -628,6 +628,24 @@ pub struct ErrorHasSourceMessage {
     pub expected_source_message: String,
 }
 
+/// Creates a [`HasDebugMessage`] expectation.
+pub fn has_debug_message<E>(expected: E) -> HasDebugMessage<E> {
+    HasDebugMessage { expected }
+}
+
+pub struct HasDebugMessage<E> {
+    pub expected: E,
+}
+
+/// Creates a [`HasDisplayMessage`] expectation.
+pub fn has_display_message<E>(expected: E) -> HasDisplayMessage<E> {
+    HasDisplayMessage { expected }
+}
+
+pub struct HasDisplayMessage<E> {
+    pub expected: E,
+}
+
 /// Creates an [`IsEmpty`] expectation.
 pub fn is_empty() -> IsEmpty {
     IsEmpty


### PR DESCRIPTION
For opaque types and espacially for `Error` types it can be handy to assert the debug or display string of a type.

Implemented the assertions `has_debug_message` and `does_not_have_debug_message` for types that implement `core::fmt::Debug` and the assertions `has_display_message` and `does_not_have_display_message` for types that implement `core::fmt::Display`.