### PR TITLE
feat: implement `does_not_contain` assertions for collections and iterators

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ for all iterators.
 | assertion                     | description                                                                                                             |
 |-------------------------------|-------------------------------------------------------------------------------------------------------------------------|
 | contains                      | verify that an iterator/collection contains an item that is equal to the expected value                                 |                                                
+| does_not_contain              | verify that an iterator/collection does not contain an item that is equal to the expected value                         |                                                
 | contains_exactly_in_any_order | verify that an iterator/collection contains exactly the expected values and nothing else in any order                   |
 | contains_any_of               | verify that an iterator/collection contains at least one of the given values                                            |
 | contains_all_of               | verify that an iterator/collection contains all the expected values in any order (and maybe more)                       |

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -2611,8 +2611,8 @@ pub trait AssertStringMatches {
 /// assert_that!(some_btree_map).contains(('b', 0));
 /// ```
 pub trait AssertIteratorContains<'a, U, E, R> {
-    /// Verifies that the actual collection/iterator contains the expected
-    /// value.
+    /// Verifies that the actual collection/iterator contains at least one
+    /// element that is equal to the expected value.
     ///
     /// # Examples
     ///
@@ -2634,6 +2634,30 @@ pub trait AssertIteratorContains<'a, U, E, R> {
     /// ```
     #[track_caller]
     fn contains(self, element: E) -> Spec<'a, U, R>;
+
+    /// Verifies that the actual collection/iterator does not contain an element
+    /// that is equal to the expected value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use asserting::prelude::*;
+    /// use std::collections::BTreeMap;
+    ///
+    /// let some_array = [1, 3, 5, 7];
+    /// assert_that!(some_array).does_not_contain(2);
+    ///
+    /// let some_slice = &['b', 'X', 'k', 'G'][..];
+    /// assert_that!(some_slice).does_not_contain(&'Y');
+    ///
+    /// let some_vec = vec![12, 4, 6, 10, 8];
+    /// assert_that!(some_vec).does_not_contain(5);
+    ///
+    /// let some_btree_map = BTreeMap::from_iter([('a', 3), ('b', 0), ('c', 8)]);
+    /// assert_that!(some_btree_map).does_not_contain(('d', 5));
+    /// ```
+    #[track_caller]
+    fn does_not_contain(self, element: E) -> Spec<'a, U, R>;
 }
 
 /// Assert values in a collection.

--- a/src/iterator/tests.rs
+++ b/src/iterator/tests.rs
@@ -134,3 +134,69 @@ fn verify_custom_iterator_contains_fails() {
 "]
     );
 }
+
+#[test]
+fn custom_collection_does_not_contain() {
+    let subject: CustomCollection<i32> = CustomCollection {
+        inner: vec![1, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43],
+    };
+
+    assert_that(subject)
+        .does_not_contain(2)
+        .does_not_contain(4)
+        .does_not_contain(6);
+}
+
+#[test]
+fn verify_custom_collection_does_not_contain_fails() {
+    let subject: CustomCollection<i32> = CustomCollection {
+        inner: vec![1, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43],
+    };
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .does_not_contain(19)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[r"assertion failed: expected my_thing to not contain 19
+   but was: [1, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]
+  expected: not 19
+"]
+    );
+}
+
+#[test]
+fn custom_iterator_does_not_contain() {
+    let subject: CustomIter<i32> = CustomCollection {
+        inner: vec![1, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43],
+    }
+    .into_iter();
+
+    assert_that(subject)
+        .does_not_contain(2)
+        .does_not_contain(4)
+        .does_not_contain(6);
+}
+
+#[test]
+fn verify_custom_iterator_does_not_contain_fails() {
+    let subject: CustomIter<i32> = CustomCollection {
+        inner: vec![1, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43],
+    }
+    .into_iter();
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .does_not_contain(19)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[r"assertion failed: expected my_thing to not contain 19
+   but was: [1, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]
+  expected: not 19
+"]
+    );
+}

--- a/src/slice/tests.rs
+++ b/src/slice/tests.rs
@@ -242,6 +242,62 @@ fn verify_slice_iterator_contains_fails() {
 }
 
 #[test]
+fn slice_does_not_contain() {
+    let subject: &[i32] = &[1, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43];
+
+    assert_that(subject)
+        .does_not_contain(&2)
+        .does_not_contain(&4)
+        .does_not_contain(&6);
+}
+
+#[test]
+fn verify_slice_does_not_contain_fails() {
+    let subject: &[i32] = &[1, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43];
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .does_not_contain(&19)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[r"assertion failed: expected my_thing to not contain 19
+   but was: [1, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]
+  expected: not 19
+"]
+    );
+}
+
+#[test]
+fn slice_iterator_does_not_contain() {
+    let subject: slice::Iter<'_, i32> = [1, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43].iter();
+
+    assert_that(subject)
+        .does_not_contain(&2)
+        .does_not_contain(&4)
+        .does_not_contain(&6);
+}
+
+#[test]
+fn verify_slice_iterator_does_not_contain_fails() {
+    let subject: slice::Iter<'_, i32> = [1, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43].iter();
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .does_not_contain(&19)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[r"assertion failed: expected my_thing to not contain 19
+   but was: [1, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]
+  expected: not 19
+"]
+    );
+}
+
+#[test]
 fn slice_contains_exactly_in_any_order() {
     let subject: &[i32] = &[5, 7, 11, 13, 1, 19, 11, 3, 17, 23, 23, 29, 31, 41, 37, 43];
 
@@ -837,6 +893,24 @@ mod colored {
             &["assertion failed: expected subject to contain 21\n   \
                 but was: [\u{1b}[31m13\u{1b}[0m, \u{1b}[31m5\u{1b}[0m, \u{1b}[31m7\u{1b}[0m, \u{1b}[31m19\u{1b}[0m, \u{1b}[31m1\u{1b}[0m, \u{1b}[31m3\u{1b}[0m, \u{1b}[31m11\u{1b}[0m, \u{1b}[31m29\u{1b}[0m, \u{1b}[31m23\u{1b}[0m, \u{1b}[31m31\u{1b}[0m, \u{1b}[31m37\u{1b}[0m]\n  \
                expected: \u{1b}[32m21\u{1b}[0m\n\
+            "]
+        );
+    }
+
+    #[test]
+    fn highlight_diffs_slice_does_not_contain() {
+        let subject: &[i64] = &[13, 5, 7, 19, 1, 3, 11, 29, 19, 19, 37];
+
+        let failures = verify_that(subject)
+            .with_diff_format(DIFF_FORMAT_RED_GREEN)
+            .does_not_contain(&19)
+            .display_failures();
+
+        assert_eq!(
+            failures,
+            &["assertion failed: expected subject to not contain 19\n   \
+                but was: [13, 5, 7, \u{1b}[31m19\u{1b}[0m, 1, 3, 11, 29, \u{1b}[31m19\u{1b}[0m, \u{1b}[31m19\u{1b}[0m, 37]\n  \
+               expected: not \u{1b}[32m19\u{1b}[0m\n\
             "]
         );
     }

--- a/src/vec/tests.rs
+++ b/src/vec/tests.rs
@@ -93,6 +93,34 @@ fn verify_vec_contains_fails() {
 }
 
 #[test]
+fn vec_does_not_contain() {
+    let subject: Vec<i32> = vec![1, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43];
+
+    assert_that(subject)
+        .does_not_contain(2)
+        .does_not_contain(4)
+        .does_not_contain(6);
+}
+
+#[test]
+fn verify_vec_does_not_contain_fails() {
+    let subject: Vec<i32> = vec![1, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43];
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .does_not_contain(19)
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[r"assertion failed: expected my_thing to not contain 19
+   but was: [1, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43]
+  expected: not 19
+"]
+    );
+}
+
+#[test]
 fn vec_contains_exactly_in_any_order() {
     let subject: Vec<i32> = vec![5, 7, 11, 13, 1, 19, 11, 3, 17, 23, 23, 29, 31, 41, 37, 43];
 


### PR DESCRIPTION
Sometimes it can be more expressive to assert that a collection/iterator does not contain a specific element.

Implemented `does_not_contain` assertions for collections and iterators.