### PR TITLE
feat: implement `does_not_contain_any_of` assertions for collections and iterators

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,15 +396,16 @@ Implementing this property for any type enables these assertions for that type.
 
 for all iterators.
 
-| assertion                     | description                                                                                                             |
-|-------------------------------|-------------------------------------------------------------------------------------------------------------------------|
-| contains                      | verify that an iterator/collection contains an item that is equal to the expected value                                 |                                                
-| does_not_contain              | verify that an iterator/collection does not contain an item that is equal to the expected value                         |                                                
-| contains_exactly_in_any_order | verify that an iterator/collection contains exactly the expected values and nothing else in any order                   |
-| contains_any_of               | verify that an iterator/collection contains at least one of the given values                                            |
-| contains_all_of               | verify that an iterator/collection contains all the expected values in any order (and maybe more)                       |
-| contains_only                 | verify that an iterator/collection contains only the given values and nothing else in any order and ignoring duplicates |
-| contains_only_once            | verify that an iterator/collection contains only the given values in any order and each of them only once               |
+| assertion                     | description                                                                                                                 |
+|-------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| contains                      | verify that an iterator/collection contains an item that is equal to the expected value                                     |                                                
+| does_not_contain              | verify that an iterator/collection does not contain an item that is equal to the expected value                             |                                                
+| contains_exactly_in_any_order | verify that an iterator/collection contains exactly the expected values and nothing else in any order                       |
+| contains_any_of               | verify that an iterator/collection contains at least one of the specified values                                            |
+| does_not_contain_any_of       | verify that an iterator/collection does not contain any of the specified values                                             |
+| contains_all_of               | verify that an iterator/collection contains all the expected values in any order (and maybe more)                           |
+| contains_only                 | verify that an iterator/collection contains only the specified values and nothing else in any order and ignoring duplicates |
+| contains_only_once            | verify that an iterator/collection contains only the specified values in any order and each of them only once               |
 
 for iterators that yield items in a well-defined order.
 

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -2692,7 +2692,7 @@ pub trait AssertIteratorContainsInAnyOrder<'a, S, E, R> {
     fn contains_exactly_in_any_order(self, expected: E) -> Spec<'a, S, R>;
 
     /// Verifies that the actual collection/iterator contains at least one of
-    /// the given values.
+    /// the specified values.
     ///
     /// # Examples
     ///
@@ -2714,6 +2714,30 @@ pub trait AssertIteratorContainsInAnyOrder<'a, S, E, R> {
     /// ```
     #[track_caller]
     fn contains_any_of(self, expected: E) -> Spec<'a, S, R>;
+
+    /// Verifies that the actual collection/iterator does not contain any of
+    /// the specified values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use asserting::prelude::*;
+    /// use std::collections::BTreeMap;
+    ///
+    /// let some_array = [1, 3, 5, 7];
+    /// assert_that!(some_array).does_not_contain_any_of([2, 4, 6]);
+    ///
+    /// let some_slice = &['b', 'X', 'k', 'G'][..];
+    /// assert_that!(some_slice).does_not_contain_any_of(&['a', 'A', 'c', 'd']);
+    ///
+    /// let some_vec = vec![12, 4, 6, 10, 8];
+    /// assert_that!(some_vec).does_not_contain_any_of([1, 2, 3, 5, 7]);
+    ///
+    /// let some_btree_map = BTreeMap::from_iter([('a', 3), ('b', 0), ('c', 8)]);
+    /// assert_that!(some_btree_map).does_not_contain_any_of([('x', 2), ('z', 3), ('y', 7)]);
+    /// ```
+    #[track_caller]
+    fn does_not_contain_any_of(self, expected: E) -> Spec<'a, S, R>;
 
     /// Verifies that the actual collection/iterator contains the given values
     /// in any order.

--- a/src/slice/tests.rs
+++ b/src/slice/tests.rs
@@ -356,6 +356,33 @@ fn verify_slice_contains_any_of_fails() {
 }
 
 #[test]
+fn slice_does_not_contain_any_of() {
+    let subject: &[i32] = &[5, 7, 11, 13, 1, 19, 11, 3, 17, 23, 23, 29, 31, 41, 37, 43];
+
+    assert_that(subject).does_not_contain_any_of(&[10, 2, 4, 44, 6, 8]);
+}
+
+#[test]
+fn verify_slice_does_not_contain_any_of_fails() {
+    let subject: &[i32] = &[5, 7, 11, 13, 1, 11, 3, 17, 23, 23, 29, 31, 41, 37, 43];
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .does_not_contain_any_of(&[0, 2, 4, 41, 16, 32, 64])
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing to not contain any of [0, 2, 4, 41, 16, 32, 64]
+   but was: [5, 7, 11, 13, 1, 11, 3, 17, 23, 23, 29, 31, 41, 37, 43]
+  expected: not [0, 2, 4, 41, 16, 32, 64]
+"
+        ]
+    );
+}
+
+#[test]
 fn slice_contains_all_of() {
     let subject: &[i32] = &[5, 7, 11, 13, 1, 19, 11, 3, 17, 23, 23, 29, 31, 41, 37, 43];
 
@@ -947,6 +974,23 @@ mod colored {
             "assertion failed: expected subject to contain any of [2, 4, 6, 8, 9, 10, 12, 15, 32, 20, 18]\n   \
                 but was: [\u{1b}[31m13\u{1b}[0m, \u{1b}[31m5\u{1b}[0m, \u{1b}[31m7\u{1b}[0m, \u{1b}[31m19\u{1b}[0m, \u{1b}[31m1\u{1b}[0m, \u{1b}[31m3\u{1b}[0m, \u{1b}[31m11\u{1b}[0m, \u{1b}[31m29\u{1b}[0m, \u{1b}[31m23\u{1b}[0m, \u{1b}[31m31\u{1b}[0m, \u{1b}[31m37\u{1b}[0m]\n  \
                expected: [\u{1b}[34m2\u{1b}[0m, \u{1b}[34m4\u{1b}[0m, \u{1b}[34m6\u{1b}[0m, \u{1b}[34m8\u{1b}[0m, \u{1b}[34m9\u{1b}[0m, \u{1b}[34m10\u{1b}[0m, \u{1b}[34m12\u{1b}[0m, \u{1b}[34m15\u{1b}[0m, \u{1b}[34m32\u{1b}[0m, \u{1b}[34m20\u{1b}[0m, \u{1b}[34m18\u{1b}[0m]\n\
+            "
+        ]);
+    }
+
+    #[test]
+    fn highlight_diffs_slice_does_not_contain_any_of() {
+        let subject: &[i64] = &[13, 5, 7, 19, 11, 11, 3, 11, 29, 23, 31, 37];
+
+        let failures = verify_that(subject)
+            .with_diff_format(DIFF_FORMAT_RED_BLUE)
+            .does_not_contain_any_of(&[2, 4, 6, 8, 9, 10, 11, 15, 32, 20, 18])
+            .display_failures();
+
+        assert_eq!(failures, &[
+            "assertion failed: expected subject to not contain any of [2, 4, 6, 8, 9, 10, 11, 15, 32, 20, 18]\n   \
+                but was: [13, 5, 7, 19, \u{1b}[31m11\u{1b}[0m, \u{1b}[31m11\u{1b}[0m, 3, \u{1b}[31m11\u{1b}[0m, 29, 23, 31, 37]\n  \
+               expected: not [2, 4, 6, 8, 9, 10, \u{1b}[34m11\u{1b}[0m, 15, 32, 20, 18]\n\
             "
         ]);
     }

--- a/src/vec/tests.rs
+++ b/src/vec/tests.rs
@@ -179,6 +179,33 @@ fn verify_vec_contains_any_of_fails() {
 }
 
 #[test]
+fn vec_does_not_contain_any_of() {
+    let subject: Vec<i32> = vec![5, 7, 11, 13, 1, 19, 11, 3, 17, 23, 23, 29, 31, 41, 37, 43];
+
+    assert_that(subject).does_not_contain_any_of([2, 20, 4, 40, 6, 8]);
+}
+
+#[test]
+fn verify_vec_does_not_contain_any_of_fails() {
+    let subject: Vec<i32> = vec![5, 7, 20, 1, 17, 23, 23, 40, 20, 20, 41, 37, 43];
+
+    let failures = verify_that(subject)
+        .named("my_thing")
+        .does_not_contain_any_of([2, 20, 4, 40, 8, 80])
+        .display_failures();
+
+    assert_eq!(
+        failures,
+        &[
+            r"assertion failed: expected my_thing to not contain any of [2, 20, 4, 40, 8, 80]
+   but was: [5, 7, 20, 1, 17, 23, 23, 40, 20, 20, 41, 37, 43]
+  expected: not [2, 20, 4, 40, 8, 80]
+"
+        ]
+    );
+}
+
+#[test]
 fn vec_contains_all_of() {
     let subject: Vec<i32> = vec![5, 7, 11, 13, 1, 19, 11, 3, 17, 23, 23, 29, 31, 41, 37, 43];
 


### PR DESCRIPTION
Implemented `does_not_contain_any_of` assertion for collections and iterators.