### PR TITLE
refactor!: rename trait `AssertElements` to `AssertFilteredElements`

### DIFF
--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -4003,7 +4003,7 @@ pub trait AssertMapContainsValue<E> {
 /// let subject = [42, 43, 44, 45, 46];
 /// assert_that!(subject).none_satisfies(|e| *e < 42);
 /// ```
-pub trait AssertElements<T> {
+pub trait AssertFilteredElements<T> {
     /// A spec-like type that contains a single element as the subject that is
     /// extracted from the iterator.
     ///

--- a/src/iterator/mod.rs
+++ b/src/iterator/mod.rs
@@ -1,7 +1,7 @@
 //! Implementations of assertions for `Iterator` values.
 
 use crate::assertions::{
-    AssertElements, AssertIteratorContains, AssertIteratorContainsInAnyOrder,
+    AssertFilteredElements, AssertIteratorContains, AssertIteratorContainsInAnyOrder,
     AssertIteratorContainsInOrder, AssertOrderedElements,
 };
 use crate::colored::{
@@ -783,7 +783,7 @@ where
     }
 }
 
-impl<'a, S, T, R> AssertElements<T> for Spec<'a, S, R>
+impl<'a, S, T, R> AssertFilteredElements<T> for Spec<'a, S, R>
 where
     S: IntoIterator<Item = T>,
     T: Debug,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -822,7 +822,7 @@
 //! assert_that!(person).is_over_18();
 //! ```
 //!
-//! [`AssertElements`]: assertions::AssertElements
+//! [`AssertElements`]: assertions::AssertFilteredElements
 //! [`AssertFailure`]: spec::AssertFailure
 //! [`Expectation`]: spec::Expectation
 //! [`LengthProperty`]: properties::LengthProperty

--- a/src/recursive_comparison/value/mod.rs
+++ b/src/recursive_comparison/value/mod.rs
@@ -28,7 +28,7 @@ impl Debug for Field {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = &self.name;
         let value = &self.value;
-        write!(f, "{name}: {value:?}",)
+        write!(f, "{name}: {value:?}")
     }
 }
 


### PR DESCRIPTION
**BREAKING CHANGE**: The trait `AssertElements` is renamed to `AssertFilteredElements`. No change in behavior though. If you have a custom implementation for the `AssertElements` trait just rename the trait for the implementation.